### PR TITLE
Add deployment targets to the package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -138,6 +138,13 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift-nio-transport",
+  platforms: [
+    .macOS(.v15),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .watchOS(.v11),
+    .visionOS(.v2),
+  ],
   products: products,
   dependencies: dependencies,
   targets: targets

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -43,7 +43,6 @@ private import Synchronization
 ///   }
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class Connection: Sendable {
   /// Events which can happen over the lifetime of the connection.
   package enum Event: Sendable {
@@ -350,7 +349,6 @@ package final class Connection: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection {
   package struct Stream {
     package typealias Inbound = NIOAsyncChannelInboundStream<RPCResponsePart>
@@ -412,7 +410,6 @@ extension Connection {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection {
   private enum State: Sendable {
     /// The connection is idle or connecting.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionBackoff.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionBackoff.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 package struct ConnectionBackoff {
   package var initial: Duration
   package var max: Duration

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
@@ -18,12 +18,10 @@ package import NIOCore
 package import NIOHTTP2
 internal import NIOPosix
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 package protocol HTTP2Connector: Sendable {
   func establishConnection(to address: SocketAddress) async throws -> HTTP2Connection
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 package struct HTTP2Connection: Sendable {
   /// The underlying TCP connection wrapped up for use with gRPC.
   var channel: NIOAsyncChannel<ClientConnectionEvent, Void>

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -18,7 +18,6 @@ private import DequeModule
 package import GRPCCore
 private import Synchronization
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class GRPCChannel: ClientTransport {
   private enum Input: Sendable {
     /// Close the channel, if possible.
@@ -225,7 +224,6 @@ package final class GRPCChannel: ClientTransport {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel {
   package struct Config: Sendable {
     /// Configuration for HTTP/2 connections.
@@ -254,7 +252,6 @@ extension GRPCChannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel {
   enum MakeStreamResult {
     /// A stream was created, use it.
@@ -347,7 +344,6 @@ extension GRPCChannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel {
   private func handleClose(in group: inout DiscardingTaskGroup) {
     switch self.state.withLock({ $0.close() }) {
@@ -574,7 +570,6 @@ extension GRPCChannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel {
   struct StateMachine {
     enum State {
@@ -649,7 +644,6 @@ extension GRPCChannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel.StateMachine {
   mutating func start() {
     precondition(!self.running, "channel must only be started once")

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancer.swift
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package enum LoadBalancer: Sendable {
   case roundRobin(RoundRobinLoadBalancer)
   case pickFirst(PickFirstLoadBalancer)
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension LoadBalancer {
   package init(_ loadBalancer: RoundRobinLoadBalancer) {
     self = .roundRobin(loadBalancer)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -56,7 +56,6 @@ private import Synchronization
 ///   }
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class PickFirstLoadBalancer: Sendable {
   enum Input: Sendable, Hashable {
     /// Update the addresses used by the load balancer to the following endpoints.
@@ -165,7 +164,6 @@ package final class PickFirstLoadBalancer: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer {
   private func handleUpdateEndpoint(_ endpoint: Endpoint, in group: inout DiscardingTaskGroup) {
     if endpoint.addresses.isEmpty { return }
@@ -266,7 +264,6 @@ extension PickFirstLoadBalancer {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer {
   enum State: Sendable {
     case active(Active)
@@ -279,7 +276,6 @@ extension PickFirstLoadBalancer {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer.State {
   struct Active: Sendable {
     var endpoint: Endpoint?
@@ -308,7 +304,6 @@ extension PickFirstLoadBalancer.State {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer.State.Active {
   mutating func updateEndpoint(
     _ endpoint: Endpoint,
@@ -471,7 +466,6 @@ extension PickFirstLoadBalancer.State.Active {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer.State.Closing {
   mutating func updateSubchannelConnectivityState(
     _ connectivityState: ConnectivityState,
@@ -512,7 +506,6 @@ extension PickFirstLoadBalancer.State.Closing {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PickFirstLoadBalancer.State {
   enum OnUpdateEndpoint {
     case connect(Subchannel, close: Subchannel?)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -58,7 +58,6 @@ private import NIOConcurrencyHelpers
 ///   }
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class RoundRobinLoadBalancer: Sendable {
   enum Input: Sendable, Hashable {
     /// Update the addresses used by the load balancer to the following endpoints.
@@ -198,7 +197,6 @@ package final class RoundRobinLoadBalancer: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RoundRobinLoadBalancer {
   /// Handles an update in endpoints.
   ///
@@ -340,7 +338,6 @@ extension RoundRobinLoadBalancer {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RoundRobinLoadBalancer {
   private enum State {
     case active(Active)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -43,7 +43,6 @@ private import Synchronization
 ///   }
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class Subchannel: Sendable {
   package enum Event: Sendable, Hashable {
     /// The connection received a GOAWAY and will close soon. No new streams
@@ -117,7 +116,6 @@ package final class Subchannel: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Subchannel {
   /// A stream of events which can happen to the subchannel.
   package var events: AsyncStream<Event> {
@@ -190,7 +188,6 @@ extension Subchannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Subchannel {
   private func handleConnectInput(in group: inout DiscardingTaskGroup) {
     let connection = self.state.withLock { state in
@@ -368,7 +365,6 @@ extension Subchannel {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Subchannel {
   ///            ┌───────────────┐
   ///   ┌───────▶│ NOT CONNECTED │───────────shutDown─────────────┐

--- a/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
@@ -16,7 +16,6 @@
 
 internal import DequeModule
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RequestQueue {
   typealias Continuation = CheckedContinuation<LoadBalancer, any Error>
 

--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -18,7 +18,6 @@ internal import GRPCCore
 internal import NIOCore
 internal import NIOHTTP2
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCClientStreamHandler: ChannelDuplexHandler {
   typealias InboundIn = HTTP2Frame.FramePayload
   typealias InboundOut = RPCResponsePart
@@ -56,7 +55,6 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
 
 // - MARK: ChannelInboundHandler
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCClientStreamHandler {
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     self.isReading = true
@@ -176,7 +174,6 @@ extension GRPCClientStreamHandler {
 
 // - MARK: ChannelOutboundHandler
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCClientStreamHandler {
   func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
     switch self.unwrapOutboundIn(data) {

--- a/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
@@ -50,7 +50,6 @@ extension HTTP2ClientTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct Keepalive: Sendable, Hashable {
     /// The amount of time to wait after reading data before sending a keepalive ping.
     ///
@@ -72,7 +71,6 @@ extension HTTP2ClientTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct Connection: Sendable, Hashable {
     /// The maximum amount of time a connection may be idle before it's closed.
     ///
@@ -102,7 +100,6 @@ extension HTTP2ClientTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct Backoff: Sendable, Hashable {
     /// The initial duration to wait before reattempting to establish a connection.
     public var initial: Duration

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
@@ -26,7 +26,6 @@ private import Musl
 #error("The GRPCNIOTransportCore module was unable to identify your C library.")
 #endif
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 /// An asynchronous non-blocking DNS resolver built on top of the libc `getaddrinfo` function.
 package enum DNSResolver {
   private static let dispatchQueue = DispatchQueue(
@@ -134,7 +133,6 @@ package enum DNSResolver {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension DNSResolver {
   /// `Error` that may be thrown based on the error code returned by `getaddrinfo`.
   package struct GetAddrInfoError: Error, Hashable, CustomStringConvertible {
@@ -150,7 +148,6 @@ extension DNSResolver {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension DNSResolver {
   /// `Error` that may be thrown based on the system error encountered by `inet_ntop`.
   package struct InetNetworkToPresentationError: Error, Hashable {
@@ -162,7 +159,6 @@ extension DNSResolver {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension SocketAddress.IPv4 {
   fileprivate init(_ address: sockaddr_in) throws {
     let presentationAddress = try withUnsafePointer(to: address.sin_addr) { addressPtr in
@@ -177,7 +173,6 @@ extension SocketAddress.IPv4 {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension SocketAddress.IPv6 {
   fileprivate init(_ address: sockaddr_in6) throws {
     let presentationAddress = try withUnsafePointer(to: address.sin6_addr) { addressPtr in

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+DNS.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+DNS.swift
@@ -50,7 +50,6 @@ extension ResolvableTarget where Self == ResolvableTargets.DNS {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/DNS`` targets.
   public struct DNS: NameResolverFactory {
@@ -66,7 +65,6 @@ extension NameResolvers {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers.DNS {
   struct Resolver: Sendable {
     var target: ResolvableTargets.DNS
@@ -97,7 +95,6 @@ extension NameResolvers.DNS {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers.DNS.Resolver: AsyncSequence {
   typealias Element = NameResolutionResult
 

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv4.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv4.swift
@@ -54,7 +54,6 @@ extension ResolvableTarget where Self == ResolvableTargets.IPv4 {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/IPv4`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv6.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv6.swift
@@ -54,7 +54,6 @@ extension ResolvableTarget where Self == ResolvableTargets.IPv6 {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/IPv6`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
@@ -40,7 +40,6 @@ extension ResolvableTarget where Self == ResolvableTargets.UnixDomainSocket {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/UnixDomainSocket`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+VSOCK.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+VSOCK.swift
@@ -44,7 +44,6 @@ extension ResolvableTarget where Self == ResolvableTargets.VirtualSocket {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/VirtualSocket`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
@@ -17,7 +17,6 @@
 public import GRPCCore
 
 /// A name resolver can provide resolved addresses and service configuration values over time.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct NameResolver: Sendable {
   /// A sequence of name resolution results.
   ///
@@ -60,7 +59,6 @@ public struct NameResolver: Sendable {
 
 /// The result of name resolution, a list of endpoints to connect to and the service
 /// configuration reported by the resolver.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct NameResolutionResult: Hashable, Sendable {
   /// A list of endpoints to connect to.
   public var endpoints: [Endpoint]
@@ -94,7 +92,6 @@ public struct Endpoint: Hashable, Sendable {
 }
 
 /// A resolver capable of resolving targets of type ``Target``.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol NameResolverFactory<Target> {
   /// The type of ``ResolvableTarget`` this factory makes resolvers for.
   associatedtype Target: ResolvableTarget
@@ -106,7 +103,6 @@ public protocol NameResolverFactory<Target> {
   func resolver(for target: Target) -> NameResolver
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolverFactory {
   /// Returns whether the given target is compatible with this factory.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolverRegistry.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolverRegistry.swift
@@ -37,7 +37,6 @@
 ///   // ...
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct NameResolverRegistry {
   private enum Factory {
     case dns(NameResolvers.DNS)

--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -390,7 +390,6 @@ private enum GRPCStreamStateMachineState {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 struct GRPCStreamStateMachine {
   private var state: GRPCStreamStateMachineState
   private var configuration: GRPCStreamStateMachineConfiguration
@@ -627,7 +626,6 @@ struct GRPCStreamStateMachine {
 
 // - MARK: Client
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCStreamStateMachine {
   private func makeClientHeaders(
     methodDescriptor: MethodDescriptor,
@@ -1229,7 +1227,6 @@ extension GRPCStreamStateMachine {
 
 // - MARK: Server
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCStreamStateMachine {
   private func formResponseHeaders(
     in headers: inout HPACKHeaders,
@@ -1897,7 +1894,6 @@ extension MethodDescriptor {
 }
 
 extension RPCError {
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   fileprivate init(_ reason: GRPCStreamStateMachine.UnexpectedInboundCloseReason) {
     switch reason {
     case .streamReset:
@@ -1914,14 +1910,12 @@ extension RPCError {
 }
 
 extension Status {
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   fileprivate init(_ error: RPCError) {
     self = Status(code: Status.Code(error.code), message: error.message)
   }
 }
 
 extension RPCError {
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   init(_ invalidState: GRPCStreamStateMachine.InvalidState) {
     self = RPCError(code: .internalError, message: "Invalid state", cause: invalidState)
   }

--- a/Sources/GRPCNIOTransportCore/Internal/CallOptions+MethodConfig.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/CallOptions+MethodConfig.swift
@@ -16,7 +16,6 @@
 
 package import GRPCCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   package mutating func formUnion(with methodConfig: MethodConfig?) {
     guard let methodConfig = methodConfig else { return }

--- a/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
@@ -16,7 +16,6 @@
 
 internal import GRPCCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let element: Element
 
@@ -41,7 +40,6 @@ private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RPCAsyncSequence where Element: Sendable, Failure == any Error {
   static func constant(_ element: Element) -> RPCAsyncSequence<Element, any Error> {
     return RPCAsyncSequence(wrapping: ConstantAsyncSequence(element: element))

--- a/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension DiscardingTaskGroup {
   /// Adds a child task to the group which is individually cancellable.
   ///
@@ -62,7 +61,6 @@ extension DiscardingTaskGroup {
 }
 
 @usableFromInline
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct CancellableTaskHandle: Sendable {
   @usableFromInline
   private(set) var continuation: AsyncStream<Void>.Continuation

--- a/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
@@ -24,7 +24,6 @@ package import GRPCCore
 /// service, or set a default configuration for all methods by calling ``setDefaultConfig(_:)``.
 ///
 /// Use the subscript to get and set configurations for specific methods.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 package struct MethodConfigs: Sendable, Hashable {
   private var elements: [MethodConfig.Name: MethodConfig]
 

--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -19,7 +19,6 @@ package import NIOCore
 internal import NIOHPACK
 package import NIOHTTP2
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ChannelPipeline.SynchronousOperations {
   package typealias HTTP2ConnectionChannel = NIOAsyncChannel<HTTP2Frame, HTTP2Frame>
   package typealias HTTP2StreamMultiplexer = NIOHTTP2Handler.AsyncStreamMultiplexer<
@@ -108,7 +107,6 @@ extension ChannelPipeline.SynchronousOperations {
 }
 
 extension ChannelPipeline.SynchronousOperations {
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   package func configureGRPCClientPipeline(
     channel: any Channel,
     config: GRPCChannel.Config

--- a/Sources/GRPCNIOTransportCore/Internal/ProcessUniqueID.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/ProcessUniqueID.swift
@@ -17,7 +17,6 @@
 private import Synchronization
 
 /// An ID which is unique within this process.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
   private static let source = Atomic(UInt64(0))
   private let rawValue: UInt64
@@ -33,7 +32,6 @@ struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a subchannel.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   package init() {}
@@ -43,7 +41,6 @@ package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a load-balancer.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {
@@ -52,7 +49,6 @@ struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for an entry in a queue.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct QueueEntryID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {

--- a/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Result where Failure == any Error {
   /// Like `Result(catching:)`, but `async`.
   ///

--- a/Sources/GRPCNIOTransportCore/ListeningServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/ListeningServerTransport.swift
@@ -18,13 +18,11 @@ public import GRPCCore
 
 /// A transport which refines `ServerTransport` to provide the socket address of a listening
 /// server.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol ListeningServerTransport: ServerTransport {
   /// Returns the listening address of the server transport once it has started.
   var listeningAddress: SocketAddress { get async throws }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCServer {
   /// Returns the listening address of the server transport once it has started.
   ///

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -23,7 +23,6 @@ private import Synchronization
 /// Provides the common functionality for a `NIO`-based server transport.
 ///
 /// - SeeAlso: ``HTTP2ListenerFactory``.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package final class CommonHTTP2ServerTransport<
   ListenerFactory: HTTP2ListenerFactory
 >: ServerTransport, ListeningServerTransport {

--- a/Sources/GRPCNIOTransportCore/Server/Connection/GRPCServerFlushNotificationHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/GRPCServerFlushNotificationHandler.swift
@@ -16,7 +16,6 @@
 
 internal import NIOCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCServerFlushNotificationHandler: ChannelOutboundHandler {
   typealias OutboundIn = Any
   typealias OutboundOut = Any

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnection.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnection.swift
@@ -17,7 +17,6 @@
 package import GRPCCore
 package import NIOCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public enum ServerConnection {
   public enum Stream {
     package struct Outbound: ClosableRPCWriterProtocol {

--- a/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
@@ -18,7 +18,6 @@ package import GRPCCore
 package import NIOCore
 package import NIOHTTP2
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChannelHandler {
   package typealias InboundIn = HTTP2Frame.FramePayload
   package typealias InboundOut = RPCRequestPart
@@ -64,7 +63,6 @@ package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChan
 
 // - MARK: ChannelInboundHandler
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCServerStreamHandler {
   package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     self.isReading = true
@@ -201,7 +199,6 @@ extension GRPCServerStreamHandler {
 
 // - MARK: ChannelOutboundHandler
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCServerStreamHandler {
   package func write(
     context: ChannelHandlerContext,

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ListenerFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ListenerFactory.swift
@@ -20,7 +20,6 @@ package import NIOExtras
 /// A factory to produce `NIOAsyncChannel`s to listen for new HTTP/2 connections.
 ///
 /// - SeeAlso: ``CommonHTTP2ServerTransport``
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package protocol HTTP2ListenerFactory: Sendable {
   typealias AcceptedChannel = (
     ChannelPipeline.SynchronousOperations.HTTP2ConnectionChannel,

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
@@ -45,7 +45,6 @@ extension HTTP2ServerTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct Keepalive: Sendable, Hashable {
     /// The amount of time to wait after reading data before sending a keepalive ping.
     public var time: Duration
@@ -79,7 +78,6 @@ extension HTTP2ServerTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct ClientKeepaliveBehavior: Sendable, Hashable {
     /// The minimum allowed interval the client is allowed to send keep-alive pings.
     /// Pings more frequent than this interval count as 'strikes' and the connection is closed if there are
@@ -106,7 +104,6 @@ extension HTTP2ServerTransport.Config {
     }
   }
 
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public struct Connection: Sendable, Hashable {
     /// The maximum amount of time a connection may exist before being gracefully closed.
     public var maxAge: Duration?

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
@@ -23,7 +23,6 @@ public import NIOPosix  // has to be public because of default argument value in
 private import NIOSSL
 #endif
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {
   /// A `ClientTransport` using HTTP/2 built on top of `NIOPosix`.
   ///
@@ -125,7 +124,6 @@ extension HTTP2ClientTransport {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.Posix {
   struct Connector: HTTP2Connector {
     private let config: HTTP2ClientTransport.Posix.Config
@@ -190,7 +188,6 @@ extension HTTP2ClientTransport.Posix {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.Posix {
   public struct Config: Sendable {
     /// Configuration for HTTP/2 connections.
@@ -254,7 +251,6 @@ extension HTTP2ClientTransport.Posix {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel.Config {
   init(posix: HTTP2ClientTransport.Posix.Config) {
     self.init(
@@ -266,7 +262,6 @@ extension GRPCChannel.Config {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientTransport where Self == HTTP2ClientTransport.Posix {
   /// Creates a new Posix based HTTP/2 client transport.
   ///

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -54,7 +54,6 @@ extension HTTP2ServerTransport {
   ///   // ...
   /// }
   /// ```
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   public struct Posix: ServerTransport, ListeningServerTransport {
     private struct ListenerFactory: HTTP2ListenerFactory {
       let config: Config
@@ -177,7 +176,6 @@ extension HTTP2ServerTransport {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ServerTransport.Posix {
   /// Config for the `Posix` transport.
   public struct Config: Sendable {
@@ -243,7 +241,6 @@ extension HTTP2ServerTransport.Posix {
 }
 
 extension ServerBootstrap {
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   fileprivate func bind<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
     childChannelInitializer: @escaping @Sendable (any Channel) -> EventLoopFuture<Output>
@@ -262,7 +259,6 @@ extension ServerBootstrap {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerTransport where Self == HTTP2ServerTransport.Posix {
   /// Create a new `Posix` based HTTP/2 server transport.
   ///

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOClientBootstrap+SocketAddress.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOClientBootstrap+SocketAddress.swift
@@ -20,7 +20,6 @@ internal import NIOCore
 internal import NIOPosix
 
 extension ClientBootstrap {
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func connect<Result: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
     _ configure: @Sendable @escaping (any Channel) -> EventLoopFuture<Result>

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
@@ -126,7 +126,6 @@ extension CertificateVerification {
 }
 
 extension TLSConfiguration {
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   package init(_ tlsConfig: HTTP2ServerTransport.Posix.Config.TLS) throws {
     let certificateChain = try tlsConfig.certificateChain.sslCertificateSources()
     let privateKey = try NIOSSLPrivateKey(privateKey: tlsConfig.privateKey)
@@ -143,7 +142,6 @@ extension TLSConfiguration {
     self.applicationProtocols = ["grpc-exp", "h2"]
   }
 
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   package init(_ tlsConfig: HTTP2ClientTransport.Posix.Config.TLS) throws {
     self = TLSConfiguration.makeClientConfiguration()
     self.certificateChain = try tlsConfig.certificateChain.sslCertificateSources()

--- a/Sources/GRPCNIOTransportHTTP2Posix/TLSConfig.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/TLSConfig.swift
@@ -133,7 +133,6 @@ public enum TLSConfig: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ServerTransport.Posix.Config {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -220,7 +219,6 @@ extension HTTP2ServerTransport.Posix.Config {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.Posix.Config {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -22,7 +22,6 @@ public import NIOCore  // has to be public because of EventLoopGroup param in in
 
 private import Network
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {
   /// A `ClientTransport` using HTTP/2 built on top of `NIOTransportServices`.
   ///
@@ -124,7 +123,6 @@ extension HTTP2ClientTransport {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.TransportServices {
   struct Connector: HTTP2Connector {
     private let config: HTTP2ClientTransport.TransportServices.Config
@@ -172,7 +170,6 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.TransportServices {
   /// Configuration for the `TransportServices` transport.
   public struct Config: Sendable {
@@ -237,7 +234,6 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel.Config {
   init(transportServices config: HTTP2ClientTransport.TransportServices.Config) {
     self.init(
@@ -249,7 +245,6 @@ extension GRPCChannel.Config {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOTSConnectionBootstrap {
   fileprivate func connect<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -272,7 +267,6 @@ extension NIOTSConnectionBootstrap {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   /// Create a new `TransportServices` based HTTP/2 client transport.
   ///
@@ -303,7 +297,6 @@ extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NWProtocolTLS.Options {
   convenience init(_ tlsConfig: HTTP2ClientTransport.TransportServices.Config.TLS) throws {
     self.init()

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -28,7 +28,6 @@ private import Synchronization
 
 extension HTTP2ServerTransport {
   /// A NIO Transport Services-backed implementation of a server transport.
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   public struct TransportServices: ServerTransport, ListeningServerTransport {
     private struct ListenerFactory: HTTP2ListenerFactory {
       let config: Config
@@ -131,7 +130,6 @@ extension HTTP2ServerTransport {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ServerTransport.TransportServices {
   /// Configuration for the `TransportServices` transport.
   public struct Config: Sendable {
@@ -193,7 +191,6 @@ extension HTTP2ServerTransport.TransportServices {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension NIOTSListenerBootstrap {
   fileprivate func bind<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -216,7 +213,6 @@ extension NIOTSListenerBootstrap {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerTransport where Self == HTTP2ServerTransport.TransportServices {
   /// Create a new `TransportServices` based HTTP/2 server transport.
   ///
@@ -238,7 +234,6 @@ extension ServerTransport where Self == HTTP2ServerTransport.TransportServices {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NWProtocolTLS.Options {
   convenience init(_ tlsConfig: HTTP2ServerTransport.TransportServices.Config.TLS) throws {
     self.init()

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/TLSConfig.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/TLSConfig.swift
@@ -17,7 +17,6 @@
 #if canImport(Network)
 public import Network
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ServerTransport.TransportServices.Config {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -61,7 +60,6 @@ extension HTTP2ServerTransport.TransportServices.Config {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport.TransportServices.Config {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -19,15 +19,12 @@ import GRPCNIOTransportCore
 
 // Equatable conformance for these types is 'best effort', this is sufficient for testing but not
 // for general use.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection.Event: Equatable {}
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection.CloseReason: Equatable {}
 
 extension ClientConnectionEvent: Equatable {}
 extension ClientConnectionEvent.CloseReason: Equatable {}
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection.Event {
   package static func == (lhs: Connection.Event, rhs: Connection.Event) -> Bool {
     switch (lhs, rhs) {
@@ -47,7 +44,6 @@ extension Connection.Event {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Connection.CloseReason {
   package static func == (lhs: Connection.CloseReason, rhs: Connection.CloseReason) -> Bool {
     switch (lhs, rhs) {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionBackoffTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionBackoffTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class ConnectionBackoffTests: XCTestCase {
   func testUnjitteredBackoff() {
     let backoff = ConnectionBackoff(

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -23,7 +23,6 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ConnectionTests: XCTestCase {
   func testConnectThenClose() async throws {
     try await ConnectionTest.run(connector: .posix()) { context, event in
@@ -202,7 +201,6 @@ final class ConnectionTests: XCTestCase {
 }
 
 extension ClientBootstrap {
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func connect<T: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
     _ configure: @Sendable @escaping (any Channel) -> EventLoopFuture<T>

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
@@ -20,7 +20,6 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class GRPCChannelTests: XCTestCase {
   func testDefaultServiceConfig() throws {
     var serviceConfig = ServiceConfig()
@@ -798,7 +797,6 @@ final class GRPCChannelTests: XCTestCase {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel.Config {
   static var defaults: Self {
     Self(
@@ -816,7 +814,6 @@ extension Endpoint {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCChannel {
   fileprivate func serverAddress() async throws -> String? {
     let values: Metadata.StringValues? = try await self.withStream(

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
@@ -17,7 +17,6 @@
 import GRPCNIOTransportCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 enum LoadBalancerTest {
   struct Context {
     let servers: [(server: TestServer, address: GRPCNIOTransportCore.SocketAddress)]
@@ -163,7 +162,6 @@ enum LoadBalancerTest {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension LoadBalancerTest.Context {
   var roundRobin: RoundRobinLoadBalancer? {
     switch self.loadBalancer {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
@@ -20,7 +20,6 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class PickFirstLoadBalancerTests: XCTestCase {
   func testPickFirstConnectsToServer() async throws {
     try await LoadBalancerTest.pickFirst(servers: 1, connector: .posix()) { context, event in

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -20,7 +20,6 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class RoundRobinLoadBalancerTests: XCTestCase {
   func testMultipleConnectionsAreEstablished() async throws {
     try await LoadBalancerTest.roundRobin(servers: 3, connector: .posix()) { context, event in

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -21,7 +21,6 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class SubchannelTests: XCTestCase {
   func testMakeStreamOnIdleSubchannel() async throws {
     let subchannel = self.makeSubchannel(
@@ -569,7 +568,6 @@ final class SubchannelTests: XCTestCase {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ConnectionBackoff {
   static func fixed(at interval: Duration, jitter: Double = 0.0) -> Self {
     return Self(initial: interval, max: interval, multiplier: 1.0, jitter: jitter)

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
@@ -20,7 +20,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class RequestQueueTests: XCTestCase {
   struct AnErrorToAvoidALeak: Error {}
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -21,7 +21,6 @@ import NIOCore
 import NIOHTTP2
 import NIOPosix
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 enum ConnectionTest {
   struct Context {
     var server: Server
@@ -61,7 +60,6 @@ enum ConnectionTest {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ConnectionTest {
   /// A server which only expected to accept a single connection.
   final class Server {
@@ -142,7 +140,6 @@ extension ConnectionTest {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ConnectionTest {
   /// Succeeds a promise when a SETTINGS frame ack has been read.
   private final class SucceedOnSettingsAck: ChannelInboundHandler {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
@@ -20,7 +20,6 @@ import NIOCore
 import NIOHTTP2
 import NIOPosix
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == ThrowingConnector {
   /// A connector which throws the given error on a connect attempt.
   static func throwing(_ error: RPCError) -> Self {
@@ -28,7 +27,6 @@ extension HTTP2Connector where Self == ThrowingConnector {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == NeverConnector {
   /// A connector which fatal errors if a connect attempt is made.
   static var never: Self {
@@ -36,7 +34,6 @@ extension HTTP2Connector where Self == NeverConnector {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == NIOPosixConnector {
   /// A connector which uses NIOPosix to establish a connection.
   static func posix(
@@ -56,7 +53,6 @@ extension HTTP2Connector where Self == NIOPosixConnector {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowingConnector: HTTP2Connector {
   private let error: RPCError
 
@@ -71,7 +67,6 @@ struct ThrowingConnector: HTTP2Connector {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct NeverConnector: HTTP2Connector {
   func establishConnection(
     to address: GRPCNIOTransportCore.SocketAddress
@@ -80,7 +75,6 @@ struct NeverConnector: HTTP2Connector {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct NIOPosixConnector: HTTP2Connector {
   private let eventLoopGroup: any EventLoopGroup
   private let maxIdleTime: TimeAmount?

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/NameResolvers.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/NameResolvers.swift
@@ -17,7 +17,6 @@
 import GRPCCore
 import GRPCNIOTransportCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension NameResolver {
   static func `static`(
     endpoints: [Endpoint],
@@ -43,7 +42,6 @@ extension NameResolver {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let result: Result<Element, any Error>
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
@@ -23,7 +23,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class TestServer: Sendable {
   private let eventLoopGroup: any EventLoopGroup
   private typealias Stream = NIOAsyncChannel<RPCRequestPart, RPCResponsePart>
@@ -145,7 +144,6 @@ final class TestServer: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension TestServer {
   enum RunHandler {
     case echo

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -24,7 +24,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCClientStreamHandlerTests: XCTestCase {
   func testH2FramesAreIgnored() throws {
     let handler = GRPCClientStreamHandler(

--- a/Tests/GRPCNIOTransportCoreTests/Client/HTTP2ClientTransportConfigTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/HTTP2ClientTransportConfigTests.swift
@@ -17,7 +17,6 @@
 import GRPCNIOTransportCore
 import XCTest
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class HTTP2ClientTransportConfigTests: XCTestCase {
   func testCompressionDefaults() {
     let config = HTTP2ClientTransport.Config.Compression.defaults

--- a/Tests/GRPCNIOTransportCoreTests/Client/Resolver/NameResolverRegistryTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Resolver/NameResolverRegistryTests.swift
@@ -18,7 +18,6 @@ import GRPCCore
 import GRPCNIOTransportCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class NameResolverRegistryTests: XCTestCase {
   struct FailingResolver: NameResolverFactory {
     typealias Target = StringTarget

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -135,7 +135,6 @@ extension HPACKHeaders {
   ]
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCStreamClientStateMachineTests: XCTestCase {
   private func makeClientStateMachine(
     targetState: TargetStateMachineState,
@@ -1332,7 +1331,6 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCStreamServerStateMachineTests: XCTestCase {
   private func makeServerStateMachine(
     targetState: TargetStateMachineState,
@@ -2802,7 +2800,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 }
 
 extension XCTestCase {
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   func assertRejectedRPC(
     _ action: GRPCStreamStateMachine.OnMetadataReceived,
     expression: (HPACKHeaders) throws -> Void
@@ -2839,7 +2836,6 @@ extension XCTestCase {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCStreamStateMachine.OnNextOutboundFrame {
   public static func == (
     lhs: GRPCStreamStateMachine.OnNextOutboundFrame,
@@ -2860,5 +2856,4 @@ extension GRPCStreamStateMachine.OnNextOutboundFrame {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension GRPCStreamStateMachine.OnNextOutboundFrame: Equatable {}

--- a/Tests/GRPCNIOTransportCoreTests/Internal/ProcessUniqueIDTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/ProcessUniqueIDTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ProcessUniqueIDTests: XCTestCase {
   func testProcessUniqueIDIsUnique() {
     var ids: Set<ProcessUniqueID> = []

--- a/Tests/GRPCNIOTransportCoreTests/Internal/TimerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/TimerTests.swift
@@ -20,7 +20,6 @@ import NIOEmbedded
 import Synchronization
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal final class TimerTests: XCTestCase {
   func testScheduleOneOffTimer() {
     let loop = EmbeddedEventLoop()

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -23,7 +23,6 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCServerStreamHandlerTests: XCTestCase {
   func testH2FramesAreIgnored() throws {
     let channel = EmbeddedChannel()

--- a/Tests/GRPCNIOTransportCoreTests/Server/HTTP2ServerTransportConfigTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/HTTP2ServerTransportConfigTests.swift
@@ -17,7 +17,6 @@
 import GRPCNIOTransportCore
 import XCTest
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class HTTP2ServerTransportConfigTests: XCTestCase {
   func testCompressionDefaults() {
     let config = HTTP2ServerTransport.Config.Compression.defaults

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/AtomicCounter.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/AtomicCounter.swift
@@ -16,7 +16,6 @@
 
 import Synchronization
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class AtomicCounter: Sendable {
   private let counter: Atomic<Int>
 

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
@@ -26,7 +26,6 @@ extension MethodDescriptor {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension MethodConfig.Name {
   init(_ descriptor: MethodDescriptor) {
     self = MethodConfig.Name(service: descriptor.service, method: descriptor.method)

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/Task+Poll.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/Task+Poll.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Task where Success == Never, Failure == Never {
   static func poll(
     every interval: Duration,

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/XCTest+Utilities.swift
@@ -40,13 +40,11 @@ func XCTAssertDescription(
   XCTAssertEqual(String(describing: subject), expected, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTUnwrapAsync<T>(_ expression: () async throws -> T?) async throws -> T {
   let value = try await expression()
   return try XCTUnwrap(value)
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T, E: Error>(
   ofType: E.Type = E.self,
   _ expression: () async throws -> T,
@@ -70,7 +68,6 @@ func XCTAssert<T>(_ value: Any, as type: T.Type, _ verify: (T) throws -> Void) r
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 func XCTPoll(
   every interval: Duration,
   timeLimit: Duration = .seconds(5),

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -16,7 +16,6 @@
 
 import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal struct ControlClient {
   private let client: GRPCCore.GRPCClient
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -17,7 +17,6 @@
 import Foundation
 import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ControlService: RegistrableRPCService {
   func registerMethods(with router: inout RPCRouter) {
     router.registerHandler(
@@ -55,7 +54,6 @@ struct ControlService: RegistrableRPCService {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ControlService {
   private func handle(
     request: StreamingServerRequest<ControlInput>

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
@@ -23,7 +23,6 @@ import XCTest
 import NIOSSL
 #endif
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -20,7 +20,6 @@ import GRPCNIOTransportCore
 import GRPCNIOTransportHTTP2TransportServices
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   private static let p12bundleURL = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()  // (this file)

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -20,7 +20,6 @@ import GRPCNIOTransportHTTP2Posix
 import GRPCNIOTransportHTTP2TransportServices
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportTests: XCTestCase {
   // A combination of client and server transport kinds.
   struct Transport: Sendable, CustomStringConvertible {
@@ -1429,7 +1428,6 @@ final class HTTP2TransportTests: XCTestCase {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension [HTTP2TransportTests.Transport] {
   static let supported = [
     HTTP2TransportTests.Transport(server: .posix, client: .posix),

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/HTTP2StatusCodeServer.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/HTTP2StatusCodeServer.swift
@@ -23,7 +23,6 @@ import NIOPosix
 /// An HTTP/2 test server which only responds to request headers by sending response headers and
 /// then closing. Each stream will be closed with the ":status" set to the value of the
 /// "response-status" header field in the request headers.
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class HTTP2StatusCodeServer: Sendable {
   private let address: EventLoopPromise<GRPCNIOTransportCore.SocketAddress.IPv4>
   private let eventLoopGroup: MultiThreadedEventLoopGroup


### PR DESCRIPTION
Motivation:

Core components of grpc-swift v2 require API from the latest SDKs. This causes a proliferation of availability annotations through our API. Rather than doing this we can set the minimum platforms in the package manifest.

Modifications:

- Remove availability annotations
- Set platforms in the package manifest

Result:

- Less boilerplate
- Users must set platforms in their package manifest