### PR TITLE
Surface transient channel errors

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -68,7 +68,7 @@ package final class Connection: Sendable {
     /// Closed because the remote peer initiate shutdown (i.e. sent a GOAWAY frame).
     case remote
     /// Closed because the connection encountered an unexpected error.
-    case error(any Error, wasIdle: Bool)
+    case error(RPCError, wasIdle: Bool)
   }
 
   /// Inputs to the 'run' method.
@@ -236,6 +236,7 @@ package final class Connection: Sendable {
     // This state is tracked here so that if the connection events sequence finishes and the
     // connection never became ready then the connection can report that the connect failed.
     var isReady = false
+    var unexpectedCloseError: (any Error)?
 
     func makeNeverReadyError(cause: (any Error)?) -> RPCError {
       return RPCError(
@@ -265,10 +266,15 @@ package final class Connection: Sendable {
             // The connection will close at some point soon, yield a notification for this
             // because the close might not be imminent and this could result in address resolution.
             self.event.continuation.yield(.goingAway(errorCode, reason))
-          case .idle, .keepaliveExpired, .initiatedLocally, .unexpected:
+          case .idle, .keepaliveExpired, .initiatedLocally:
             // The connection will be closed imminently in these cases there's no need to do
             // anything.
             ()
+          case .unexpected(let error, _):
+            // The connection will be closed imminently in this case.
+            // We'll store the error that caused the unexpected closure so we
+            // can surface it.
+            unexpectedCloseError = error
           }
 
           // Take the reason with the highest precedence. A GOAWAY may be superseded by user
@@ -318,7 +324,7 @@ package final class Connection: Sendable {
         finalEvent = .closed(connectionCloseReason)
       } else {
         // The connection never became ready, this therefore counts as a failed connect attempt.
-        finalEvent = .connectFailed(makeNeverReadyError(cause: nil))
+        finalEvent = .connectFailed(makeNeverReadyError(cause: unexpectedCloseError))
       }
 
       // The connection events sequence has finished: the connection is now closed.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -130,13 +130,14 @@ package final class Connection: Sendable {
     func establishConnectionOrThrow() async throws(RPCError) -> HTTP2Connection {
       do {
         return try await self.http2Connector.establishConnection(to: self.address)
+      } catch let error as RPCError {
+        throw error
       } catch {
-        throw (error as? RPCError)
-          ?? RPCError(
-            code: .unavailable,
-            message: "Could not establish a connection to \(self.address).",
-            cause: error
-          )
+        throw RPCError(
+          code: .unavailable,
+          message: "Could not establish a connection to \(self.address).",
+          cause: error
+        )
       }
     }
     let connectResult = await Result(catching: establishConnectionOrThrow)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectivityState.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectivityState.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+package import GRPCCore
+
 package enum ConnectivityState: Sendable, Hashable {
   /// This channel isn't trying to create a connection because of a lack of new or pending RPCs.
   ///
@@ -34,7 +36,7 @@ package enum ConnectivityState: Sendable, Hashable {
   /// establish a connection again. Since retries are done with exponential backoff, channels that
   /// fail to connect will start out spending very little time in this state but as the attempts
   /// fail repeatedly, the channel will spend increasingly large amounts of time in this state.
-  case transientFailure
+  case transientFailure(cause: RPCError)
 
   /// This channel has started shutting down. Any new RPCs should fail immediately. Pending RPCs
   /// may continue running until the application cancels them. Channels may enter this state either

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -765,13 +765,7 @@ extension GRPCChannel.StateMachine {
           let continuations = state.queue.removeFastFailingEntries()
           actions.resumeContinuations = ConnectivityStateChangeActions.ResumableContinuations(
             continuations: continuations,
-            result: .failure(
-              RPCError(
-                code: .unavailable,
-                message: "Channel isn't ready.",
-                cause: cause
-              )
-            )
+            result: .failure(cause)
           )
 
         case .shutdown:  // shutdown includes shutting down

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -256,8 +256,8 @@ extension Subchannel {
     switch event {
     case .connectSucceeded:
       self.handleConnectSucceededEvent()
-    case .connectFailed:
-      self.handleConnectFailedEvent(in: &group)
+    case .connectFailed(let cause):
+      self.handleConnectFailedEvent(in: &group, error: cause)
     case .goingAway:
       self.handleGoingAwayEvent()
     case .closed(let reason):
@@ -282,7 +282,7 @@ extension Subchannel {
     }
   }
 
-  private func handleConnectFailedEvent(in group: inout DiscardingTaskGroup) {
+  private func handleConnectFailedEvent(in group: inout DiscardingTaskGroup, error: any Error) {
     let onConnectFailed = self.state.withLock { $0.connectFailed(connector: self.connector) }
     switch onConnectFailed {
     case .connect(let connection):
@@ -290,8 +290,17 @@ extension Subchannel {
       self.runConnection(connection, in: &group)
 
     case .backoff(let duration):
+      let transientFailureCause = (error as? RPCError) ?? RPCError(
+        code: .unavailable,
+        message: "All addresses have been tried: backing off.",
+        cause: error
+      )
       // All addresses have been tried, backoff for some time.
-      self.event.continuation.yield(.connectivityStateChanged(.transientFailure))
+      self.event.continuation.yield(
+        .connectivityStateChanged(
+          .transientFailure(cause: transientFailureCause)
+        )
+      )
       group.addTask {
         do {
           try await Task.sleep(for: duration)
@@ -334,9 +343,9 @@ extension Subchannel {
     case .emitIdle:
       self.event.continuation.yield(.connectivityStateChanged(.idle))
 
-    case .emitTransientFailureAndReconnect:
+    case .emitTransientFailureAndReconnect(let cause):
       // Unclean closes trigger a transient failure state change and a name resolution.
-      self.event.continuation.yield(.connectivityStateChanged(.transientFailure))
+      self.event.continuation.yield(.connectivityStateChanged(.transientFailure(cause: cause)))
       self.event.continuation.yield(.requiresNameResolution)
       // Attempt to reconnect.
       self.handleConnectInput(in: &group)
@@ -632,7 +641,7 @@ extension Subchannel {
     enum OnClosed {
       case nothing
       case emitIdle
-      case emitTransientFailureAndReconnect
+      case emitTransientFailureAndReconnect(cause: RPCError)
       case finish(emitShutdown: Bool)
     }
 
@@ -646,9 +655,15 @@ extension Subchannel {
           self = .notConnected(NotConnected(from: state))
           onClosed = .emitIdle
 
-        case .keepaliveTimeout, .error(_, wasIdle: false):
+        case .keepaliveTimeout:
           self = .notConnected(NotConnected(from: state))
-          onClosed = .emitTransientFailureAndReconnect
+          onClosed = .emitTransientFailureAndReconnect(
+            cause: RPCError(code: .unavailable, message: "The keepalive timed out.")
+          )
+
+        case .error(let error, wasIdle: false):
+          self = .notConnected(NotConnected(from: state))
+          onClosed = .emitTransientFailureAndReconnect(cause: error)
 
         case .initiatedLocally:
           // Should be in the 'shuttingDown' state.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -290,11 +290,13 @@ extension Subchannel {
       self.runConnection(connection, in: &group)
 
     case .backoff(let duration):
-      let transientFailureCause = (error as? RPCError) ?? RPCError(
-        code: .unavailable,
-        message: "All addresses have been tried: backing off.",
-        cause: error
-      )
+      let transientFailureCause =
+        (error as? RPCError)
+        ?? RPCError(
+          code: .unavailable,
+          message: "All addresses have been tried: backing off.",
+          cause: error
+        )
       // All addresses have been tried, backoff for some time.
       self.event.continuation.yield(
         .connectivityStateChanged(

--- a/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-extension Result where Failure == any Error {
+extension Result {
   /// Like `Result(catching:)`, but `async`.
   ///
   /// - Parameter body: An `async` closure to catch the result of.
   @inlinable
-  init(catching body: () async throws -> Success) async {
+  init(catching body: () async throws(Failure) -> Success) async {
     do {
       self = .success(try await body())
     } catch {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -53,12 +53,8 @@ extension Connection.CloseReason {
       (.remote, .remote):
       return true
 
-    case (.error(let lhsError, let lhsStreams), .error(let rhsError, let rhsStreams)):
-      if let lhs = lhsError as? RPCError, let rhs = rhsError as? RPCError {
-        return lhs == rhs && lhsStreams == rhsStreams
-      } else {
-        return lhsStreams == rhsStreams
-      }
+    case (.error(_, let lhsStreams), .error(_, let rhsStreams)):
+      return lhs == rhs && lhsStreams == rhsStreams
 
     default:
       return false

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -53,8 +53,8 @@ extension Connection.CloseReason {
       (.remote, .remote):
       return true
 
-    case (.error(_, let lhsStreams), .error(_, let rhsStreams)):
-      return lhs == rhs && lhsStreams == rhsStreams
+    case (.error(let lhsError, let lhsStreams), .error(let rhsError, let rhsStreams)):
+      return lhsError == rhsError && lhsStreams == rhsStreams
 
     default:
       return false

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -161,7 +161,10 @@ final class SubchannelTests: XCTestCase {
         [
           .connectivityStateChanged(.idle),
           .connectivityStateChanged(.connecting),
-          .connectivityStateChanged(.transientFailure),
+          .connectivityStateChanged(.transientFailure(cause: RPCError(
+            code: .unavailable,
+            message: "All addresses have been tried: backing off."
+          ))),
           .connectivityStateChanged(.connecting),
         ]
       )
@@ -440,7 +443,9 @@ final class SubchannelTests: XCTestCase {
         .connectivityStateChanged(.idle),
         .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.ready),
-        .connectivityStateChanged(.transientFailure),
+        .connectivityStateChanged(.transientFailure(cause: RPCError(
+          code: .unavailable, message: "The TCP connection was dropped unexpectedly."
+        ))),
         .requiresNameResolution,
         .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.ready),

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -165,7 +165,8 @@ final class SubchannelTests: XCTestCase {
             .transientFailure(
               cause: RPCError(
                 code: .unavailable,
-                message: "All addresses have been tried: backing off."
+                message:
+                  "Could not establish a connection to [unix]test-connect-eventually-succeeds."
               )
             )
           ),

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -161,10 +161,14 @@ final class SubchannelTests: XCTestCase {
         [
           .connectivityStateChanged(.idle),
           .connectivityStateChanged(.connecting),
-          .connectivityStateChanged(.transientFailure(cause: RPCError(
-            code: .unavailable,
-            message: "All addresses have been tried: backing off."
-          ))),
+          .connectivityStateChanged(
+            .transientFailure(
+              cause: RPCError(
+                code: .unavailable,
+                message: "All addresses have been tried: backing off."
+              )
+            )
+          ),
           .connectivityStateChanged(.connecting),
         ]
       )
@@ -443,9 +447,14 @@ final class SubchannelTests: XCTestCase {
         .connectivityStateChanged(.idle),
         .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.ready),
-        .connectivityStateChanged(.transientFailure(cause: RPCError(
-          code: .unavailable, message: "The TCP connection was dropped unexpectedly."
-        ))),
+        .connectivityStateChanged(
+          .transientFailure(
+            cause: RPCError(
+              code: .unavailable,
+              message: "The TCP connection was dropped unexpectedly."
+            )
+          )
+        ),
         .requiresNameResolution,
         .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.ready),


### PR DESCRIPTION
This PR better surfaces transient errors happening deeper in the channel to provide more information to the user.

It depends on https://github.com/grpc/grpc-swift/pull/2083 and https://github.com/grpc/grpc-swift/pull/2084.