### PR TITLE
Add support for RPC cancellation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    exact: "2.0.0-alpha.1"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",
@@ -43,7 +43,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.32.0"
+    from: "1.34.1"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -85,7 +85,8 @@ extension ChannelPipeline.SynchronousOperations {
           scheme: scheme,
           acceptedEncodings: compressionConfig.enabledAlgorithms,
           maxPayloadSize: rpcConfig.maxRequestPayloadSize,
-          methodDescriptorPromise: methodDescriptorPromise
+          methodDescriptorPromise: methodDescriptorPromise,
+          eventLoop: streamChannel.eventLoop
         )
         try streamChannel.pipeline.syncOperations.addHandler(streamHandler)
 

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -241,19 +241,35 @@ package final class CommonHTTP2ServerTransport<
         return
       }
 
-      let rpcStream = RPCStream(
-        descriptor: descriptor,
-        inbound: RPCAsyncSequence(wrapping: inbound),
-        outbound: RPCWriter.Closable(
-          wrapping: ServerConnection.Stream.Outbound(
-            responseWriter: outbound,
-            http2Stream: stream
+      await withServerContextRPCCancellationHandle { handle in
+        stream.channel.eventLoop.execute {
+          // Sync is safe: this is on the right event loop.
+          let sync = stream.channel.pipeline.syncOperations
+
+          // Looking up the handler can fail if the channel is already closed, in which case
+          // cancel the handle directly.
+          do {
+            let handler = try sync.handler(type: GRPCServerStreamHandler.self)
+            handler.setCancellationHandle(handle)
+          } catch {
+            handle.cancel()
+          }
+        }
+
+        let rpcStream = RPCStream(
+          descriptor: descriptor,
+          inbound: RPCAsyncSequence(wrapping: inbound),
+          outbound: RPCWriter.Closable(
+            wrapping: ServerConnection.Stream.Outbound(
+              responseWriter: outbound,
+              http2Stream: stream
+            )
           )
         )
-      )
 
-      let context = ServerContext(descriptor: descriptor)
-      await streamHandler(rpcStream, context)
+        let context = ServerContext(descriptor: descriptor, cancellation: handle)
+        await streamHandler(rpcStream, context)
+      }
     }
   }
 

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -246,13 +246,13 @@ package final class CommonHTTP2ServerTransport<
           // Sync is safe: this is on the right event loop.
           let sync = stream.channel.pipeline.syncOperations
 
-          // Looking up the handler can fail if the channel is already closed, in which case
-          // cancel the handle directly.
           do {
             let handler = try sync.handler(type: GRPCServerStreamHandler.self)
             handler.setCancellationHandle(handle)
           } catch {
-            handle.cancel()
+            // Looking up the handler can fail if the channel is already closed, in which case
+            // don't execute the RPC, just return early.
+            return
           }
         }
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -117,7 +117,8 @@ extension ConnectionTest {
                 scheme: .http,
                 acceptedEncodings: .none,
                 maxPayloadSize: .max,
-                methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
+                methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
+                eventLoop: stream.eventLoop
               )
 
               return stream.eventLoop.makeCompletedFuture {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
@@ -74,7 +74,8 @@ final class TestServer: Sendable {
               scheme: .http,
               acceptedEncodings: .all,
               maxPayloadSize: .max,
-              methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
+              methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
+              eventLoop: stream.eventLoop
             )
 
             try stream.pipeline.syncOperations.addHandlers(handler)

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -17,7 +17,7 @@
 import GRPCCore
 
 internal struct ControlClient {
-  private let client: GRPCCore.GRPCClient
+  internal let client: GRPCCore.GRPCClient
 
   internal init(wrapping client: GRPCCore.GRPCClient) {
     self.client = client
@@ -82,6 +82,23 @@ internal struct ControlClient {
     try await self.client.bidirectionalStreaming(
       request: request,
       descriptor: MethodDescriptor(service: "Control", method: "BidiStream"),
+      serializer: JSONSerializer(),
+      deserializer: JSONDeserializer(),
+      options: options,
+      handler: body
+    )
+  }
+
+  internal func waitForCancellation<R>(
+    request: GRPCCore.ClientRequest<CancellationKind>,
+    options: GRPCCore.CallOptions = .defaults,
+    _ body: @Sendable @escaping (
+      _ response: GRPCCore.StreamingClientResponse<CancellationKind>
+    ) async throws -> R
+  ) async throws -> R where R: Sendable {
+    try await self.client.serverStreaming(
+      request: request,
+      descriptor: MethodDescriptor(service: "Control", method: "WaitForCancellation"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
@@ -120,6 +120,14 @@ struct ControlOutput: Codable {
   var payload: Data
 }
 
+enum CancellationKind: Codable {
+  case awaitCancelled
+  case withCancellationHandler
+}
+
+struct Empty: Codable {
+}
+
 struct JSONSerializer<Message: Encodable>: MessageSerializer {
   private let encoder = JSONEncoder()
 


### PR DESCRIPTION
Motivation:

grpc-swift has support for RPC cancellation via a cancellation handler. It should be supported here as well.

Modifications:

- Modify the server stream handler so that it holds the cancellation handle and triggers cancellation appropriately.
- Modify the server stream handling to set a cancellation handle on the appropriate stream handler.
- Update tests

Result:

HTTP/2 server transport respects stream cancellation