### PR TITLE
Move server connection management tests to swift-testing

### DIFF
--- a/Tests/GRPCNIOTransportCoreTests/XCTest+FramePayload.swift
+++ b/Tests/GRPCNIOTransportCoreTests/XCTest+FramePayload.swift
@@ -41,3 +41,23 @@ func XCTAssertPing(
     XCTFail("Expected '.ping' got '\(payload)'")
   }
 }
+
+extension HTTP2Frame.FramePayload {
+  var goAway: (lastStreamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, opaqueData: ByteBuffer?)? {
+    switch self {
+    case .goAway(let lastStreamID, let errorCode, let opaqueData):
+      return (lastStreamID, errorCode, opaqueData)
+    default:
+      return nil
+    }
+  }
+
+  var ping: (data: HTTP2PingData, ack: Bool)? {
+    switch self {
+    case .ping(let data, ack: let ack):
+      return (data, ack)
+    default:
+      return nil
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

I'd like to add more tests to the server connection management handler. Ideally these would be written using swift-testing.

Modifications:

- Migrate server connection management handler tests
- Use `package` access to avoid `@testable` import

Result:

Fewer XCTest tests