### PR TITLE
Close channel on errors

### DIFF
--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
@@ -30,6 +30,11 @@ extension ServerConnectionManagementHandler {
     /// as part of graceful shutdown.
     private let goAwayPingData: HTTP2PingData
 
+    /// Whether the connection is currently closing.
+    var isClosing: Bool {
+      self.state.isClosing
+    }
+
     /// Create a new state machine.
     ///
     /// - Parameters:
@@ -391,5 +396,14 @@ extension ServerConnectionManagementHandler.StateMachine {
     case closing(Closing)
     case closed
     case _modifying
+
+    var isClosing: Bool {
+      switch self {
+      case .closing:
+        return true
+      case .active, .closed, ._modifying:
+        return false
+      }
+    }
   }
 }

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
@@ -331,7 +331,7 @@ package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
       // This should be resolved in NIOHTTP2: https://github.com/apple/swift-nio-http2/issues/466
       //
       // Only close the connection if it's not already closing (as this is the state in which the
-      // error can be safely.
+      // error can be safely ignored).
       return !self.state.isClosing
 
     case is NIOHTTP2Errors.StreamError:

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
@@ -314,6 +314,37 @@ package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     context.fireUserInboundEventTriggered(event)
   }
 
+  package func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    if self.closeConnectionOnError(error) {
+      context.close(mode: .all, promise: nil)
+    }
+  }
+
+  private func closeConnectionOnError(_ error: any Error) -> Bool {
+    switch error {
+    case is NIOHTTP2Errors.NoSuchStream:
+      // In most cases this represents incorrect client behaviour. However, NIOHTTP2 currently
+      // emits this error if a server receives a HEADERS frame for a new stream after having sent
+      // a GOAWAY frame. This can happen when a client opening a stream races with a server
+      // shutting down.
+      //
+      // This should be resolved in NIOHTTP2: https://github.com/apple/swift-nio-http2/issues/466
+      //
+      // Only close the connection if it's not already closing (as this is the state in which the
+      // error can be safely.
+      return !self.state.isClosing
+
+    case is NIOHTTP2Errors.StreamError:
+      // Stream errors occur in streams, they are only propagated down the connection channel
+      // pipeline for vestigial reasons.
+      return false
+
+    default:
+      // Everything else is considered terminal for the connection until we know better.
+      return true
+    }
+  }
+
   package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     self.inReadLoop = true
 

--- a/Tests/GRPCNIOTransportCoreTests/HTTP2Frame+Helpers.swift
+++ b/Tests/GRPCNIOTransportCoreTests/HTTP2Frame+Helpers.swift
@@ -16,31 +16,6 @@
 
 import NIOCore
 import NIOHTTP2
-import XCTest
-
-func XCTAssertGoAway(
-  _ payload: HTTP2Frame.FramePayload,
-  verify: (HTTP2StreamID, HTTP2ErrorCode, ByteBuffer?) throws -> Void = { _, _, _ in }
-) rethrows {
-  switch payload {
-  case .goAway(let lastStreamID, let errorCode, let opaqueData):
-    try verify(lastStreamID, errorCode, opaqueData)
-  default:
-    XCTFail("Expected '.goAway' got '\(payload)'")
-  }
-}
-
-func XCTAssertPing(
-  _ payload: HTTP2Frame.FramePayload,
-  verify: (HTTP2PingData, Bool) throws -> Void = { _, _ in }
-) rethrows {
-  switch payload {
-  case .ping(let data, ack: let ack):
-    try verify(data, ack)
-  default:
-    XCTFail("Expected '.ping' got '\(payload)'")
-  }
-}
 
 extension HTTP2Frame.FramePayload {
   var goAway: (lastStreamID: HTTP2StreamID, errorCode: HTTP2ErrorCode, opaqueData: ByteBuffer?)? {


### PR DESCRIPTION
Motivation:

NIO channel pipeline's should, in most cases, be closed when an error is caught. This is not currently the case for the client and server connection channels.

Modifications:

- Close on error unless it's safe to ignore the error (such as if it's a stream-level error)

Result:

Connections are closed if something unrecoverable happens