### PR TITLE
Make sure we don't write additional DATA frames when flushing once request is finished

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -266,6 +266,8 @@ extension GRPCClientStreamHandler {
           // machine) then return.
           if self.requestFinished { return }
 
+          self.requestFinished = true
+
           // Write an empty data frame with the EOS flag set, to signal the RPC
           // request is now finished.
           context.write(
@@ -280,7 +282,6 @@ extension GRPCClientStreamHandler {
             promise: nil
           )
           context.flush()
-          self.requestFinished = true
           break loop
 
         case .awaitMoreMessages:

--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -251,10 +251,6 @@ extension GRPCClientStreamHandler {
   }
 
   private func _flush(context: ChannelHandlerContext) {
-    // If we're done writing (i.e. we have no more messages returned from state
-    // machine) then return.
-    guard !self.requestFinished else { return }
-
     do {
       loop: while true {
         switch try self.stateMachine.nextOutboundFrame() {
@@ -266,6 +262,10 @@ extension GRPCClientStreamHandler {
           )
 
         case .noMoreMessages:
+          // If we're done writing (i.e. we have no more messages returned from state
+          // machine) then return.
+          if self.requestFinished { return }
+
           // Write an empty data frame with the EOS flag set, to signal the RPC
           // request is now finished.
           context.write(

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -519,13 +519,15 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     // Half-close the outbound end: this would be triggered by finishing the client's writer.
     XCTAssertNoThrow(channel.close(mode: .output, promise: nil))
 
-    // Flush to make sure the EOS is written.
-    channel.flush()
-
     // Make sure the EOS frame was sent
     let emptyEOSFrame = try channel.assertReadDataOutbound()
     XCTAssertEqual(emptyEOSFrame.data, .byteBuffer(.init()))
     XCTAssertTrue(emptyEOSFrame.endStream)
+
+    // Make sure that, if we flush again, we're not writing anything else down
+    // the stream. We should have closed at this point.
+    channel.flush()
+    XCTAssertNil(try channel.readOutbound(as: HTTP2Frame.FramePayload.self))
 
     // Make sure we cannot write anymore because client's closed.
     XCTAssertThrowsError(


### PR DESCRIPTION
## Motivation
When a client sends a request, to signal its end to the server, it has to send an empty DATA frame with END_STREAM set.
In the current implementation, the state machine correctly signals the handler that there are no more messages to be encoded, and so the client proceeds to write the empty DATA frame with EOS set when flushing.
However, if subsequent flushes are triggered down the pipeline, the client will keep writing these empty DATA frames, which is a bug.

## Modifications
Make sure that we only write the empty DATA frame once. If we've already done it, the client can ignore subsequent flushes, as it is done.