### PR TITLE
Add NIOTS transport to E2E TLS-enabled tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
-    from: "2.27.2"
+    from: "2.29.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
@@ -334,7 +334,6 @@ package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
 
   package func errorCaught(context: ChannelHandlerContext, error: any Error) {
     if self.closeConnectionOnError(error) {
-      context.fireErrorCaught(error)
       context.close(mode: .all, promise: nil)
     }
   }

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
@@ -334,6 +334,7 @@ package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
 
   package func errorCaught(context: ChannelHandlerContext, error: any Error) {
     if self.closeConnectionOnError(error) {
+      context.fireErrorCaught(error)
       context.close(mode: .all, promise: nil)
     }
   }

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -154,7 +154,9 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
     let password = "somepassword"
     let bundle = NIOSSLPKCS12Bundle(
-      certificateChain: [try NIOSSLCertificate(bytes: certificateKeyPairs.server.certificate, format: .der)],
+      certificateChain: [
+        try NIOSSLCertificate(bytes: certificateKeyPairs.server.certificate, format: .der)
+      ],
       privateKey: try NIOSSLPrivateKey(bytes: certificateKeyPairs.server.key, format: .der)
     )
     let pkcs12Bytes = try bundle.serialize(passphrase: password.utf8)

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -25,7 +25,8 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      transportSecurity: .plaintext
+      transportSecurity: .plaintext,
+      config: .defaults
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -195,10 +196,8 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   }
 
   func testClientConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.Config.TLS.defaults
-    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults(
-      transportSecurity: .tls(grpcTLSConfig)
-    )
+    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.TLS.defaults
+    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ClientTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ClientTransport.Config.Connection.defaults)

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -25,8 +25,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      transportSecurity: .plaintext,
-      config: .defaults
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -19,57 +19,9 @@ import GRPCCore
 import GRPCNIOTransportCore
 import GRPCNIOTransportHTTP2TransportServices
 import XCTest
+import NIOSSL
 
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
-  private static let p12bundleURL = URL(fileURLWithPath: #filePath)
-    .deletingLastPathComponent()  // (this file)
-    .deletingLastPathComponent()  // GRPCHTTP2TransportTests
-    .deletingLastPathComponent()  // Tests
-    .appendingPathComponent("Sources")
-    .appendingPathComponent("GRPCSampleData")
-    .appendingPathComponent("bundle")
-    .appendingPathExtension("p12")
-
-  @Sendable private static func loadIdentity() throws -> SecIdentity {
-    let data = try Data(contentsOf: Self.p12bundleURL)
-
-    var externalFormat = SecExternalFormat.formatUnknown
-    var externalItemType = SecExternalItemType.itemTypeUnknown
-    let passphrase = "password" as CFTypeRef
-    var exportKeyParams = SecItemImportExportKeyParameters()
-    exportKeyParams.passphrase = Unmanaged.passUnretained(passphrase)
-    var items: CFArray?
-
-    let status = SecItemImport(
-      data as CFData,
-      "bundle.p12" as CFString,
-      &externalFormat,
-      &externalItemType,
-      SecItemImportExportFlags(rawValue: 0),
-      &exportKeyParams,
-      nil,
-      &items
-    )
-
-    if status != errSecSuccess {
-      XCTFail(
-        """
-        Unable to load identity from '\(Self.p12bundleURL)'. \
-        SecItemImport failed with status \(status)
-        """
-      )
-    } else if items == nil {
-      XCTFail(
-        """
-        Unable to load identity from '\(Self.p12bundleURL)'. \
-        SecItemImport failed.
-        """
-      )
-    }
-
-    return ((items! as NSArray)[0] as! SecIdentity)
-  }
-
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
@@ -198,6 +150,31 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     }
   }
 
+  @Sendable private static func loadIdentity() throws -> SecIdentity {
+    let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
+    let password = "somepassword"
+    let bundle = NIOSSLPKCS12Bundle(
+      certificateChain: [try NIOSSLCertificate(bytes: certificateKeyPairs.server.certificate, format: .der)],
+      privateKey: try NIOSSLPrivateKey(bytes: certificateKeyPairs.server.key, format: .der)
+    )
+    let pkcs12Bytes = try bundle.serialize(passphrase: password.utf8)
+    let options = [kSecImportExportPassphrase as String: password]
+    var rawItems: CFArray?
+    let status = SecPKCS12Import(
+      Data(pkcs12Bytes) as CFData,
+      options as CFDictionary,
+      &rawItems
+    )
+    guard status == errSecSuccess else {
+      XCTFail("Failed to import PKCS12 bundle: status \(status).")
+      throw HTTP2TransportNIOTransportServicesTestsError.failedToImportPKCS12
+    }
+    let items = rawItems! as! [[String: Any]]
+    let firstItem = items[0]
+    let identity = firstItem[kSecImportItemIdentity as String] as! SecIdentity
+    return identity
+  }
+
   func testServerConfig_Defaults() throws {
     let grpcTLSConfig = HTTP2ServerTransport.TransportServices.TLS.defaults(
       identityProvider: Self.loadIdentity
@@ -216,8 +193,10 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   }
 
   func testClientConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.TLS.defaults
-    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults
+    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.Config.TLS.defaults
+    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults(
+      transportSecurity: .tls(grpcTLSConfig)
+    )
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ClientTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ClientTransport.Config.Connection.defaults)
@@ -228,5 +207,9 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     XCTAssertEqual(grpcTLSConfig.serverCertificateVerification, .fullVerification)
     XCTAssertEqual(grpcTLSConfig.trustRoots, .systemDefault)
   }
+}
+
+enum HTTP2TransportNIOTransportServicesTestsError: Error {
+  case failedToImportPKCS12
 }
 #endif

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -28,8 +28,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "When using defaults, server does not perform client verification",
-    arguments: [TransportKind/*.posix, */.transportServices],
-    [TransportKind/*.posix, */.transportServices]
+    arguments: [TransportKind.posix, .transportServices],
+    [TransportKind.posix, .transportServices]
   )
   func testRPC_Defaults_OK(
     clientTransport: TransportKind,

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -31,7 +31,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "When using defaults, server does not perform client verification",
-    arguments: TransportKind.supported, TransportKind.supported
+    arguments: TransportKind.supported,
+    TransportKind.supported
   )
   func testRPC_Defaults_OK(
     clientTransport: TransportKind,
@@ -59,7 +60,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "When using mTLS defaults, both client and server verify each others' certificates",
-    arguments: TransportKind.supported, TransportKind.supported
+    arguments: TransportKind.supported,
+    TransportKind.supported
   )
   func testRPC_mTLS_OK(
     clientTransport: TransportKind,
@@ -89,7 +91,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "Error is surfaced when client fails server verification",
-    arguments: TransportKind.supported, TransportKind.supported
+    arguments: TransportKind.supported,
+    TransportKind.supported
   )
   // Verification should fail because the custom hostname is missing on the client.
   func testClientFailsServerValidation(
@@ -151,7 +154,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "Error is surfaced when server fails client verification",
-    arguments: TransportKind.supported, TransportKind.supported
+    arguments: TransportKind.supported,
+    TransportKind.supported
   )
   // Verification should fail because the client does not offer a cert that
   // the server can use for mutual verification.

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -279,7 +279,7 @@ struct HTTP2TransportTLSEnabledTests {
     )
   }
 
-  private func makeDefaultPlaintextTransportServicesClientConfig() -> ClientConfig.TransportServices {
+  private func makeDefaultPlaintextTSClientConfig() -> ClientConfig.TransportServices {
     ClientConfig.TransportServices(
       security: .plaintext,
       transport: .defaults { config in
@@ -307,7 +307,7 @@ struct HTTP2TransportTLSEnabledTests {
       return .posix(config)
 
     case .transportServices:
-      var config = self.makeDefaultPlaintextTransportServicesClientConfig()
+      var config = self.makeDefaultPlaintextTSClientConfig()
       config.security = .tls {
         $0.trustRoots = .certificates([
           .bytes(certificateKeyPairs.server.certificate, format: .der)
@@ -365,14 +365,16 @@ struct HTTP2TransportTLSEnabledTests {
       return .posix(config)
 
     case .transportServices:
-      var config = self.makeDefaultPlaintextTransportServicesClientConfig()
+      var config = self.makeDefaultPlaintextTSClientConfig()
       config.security = .mTLS {
         try self.makeSecIdentityProvider(
           certificateBytes: certificateKeyPairs.client.certificate,
           privateKeyBytes: certificateKeyPairs.client.key
         )
       } configure: {
-        $0.trustRoots = .certificates([.bytes(certificateKeyPairs.server.certificate, format: .der)])
+        $0.trustRoots = .certificates([
+          .bytes(certificateKeyPairs.server.certificate, format: .der)
+        ])
       }
       config.transport.http2.authority = serverHostname
       return .transportServices(config)
@@ -383,7 +385,7 @@ struct HTTP2TransportTLSEnabledTests {
     ServerConfig.Posix(security: .plaintext, transport: .defaults)
   }
 
-  private func makeDefaultPlaintextTransportServicesServerConfig() -> ServerConfig.TransportServices {
+  private func makeDefaultPlaintextTSServerConfig() -> ServerConfig.TransportServices {
     ServerConfig.TransportServices(security: .plaintext, transport: .defaults)
   }
 
@@ -401,7 +403,7 @@ struct HTTP2TransportTLSEnabledTests {
       return .posix(config)
 
     case .transportServices:
-      var config = self.makeDefaultPlaintextTransportServicesServerConfig()
+      var config = self.makeDefaultPlaintextTSServerConfig()
       config.security = .tls {
         try self.makeSecIdentityProvider(
           certificateBytes: certificateKeyPairs.server.certificate,
@@ -433,7 +435,7 @@ struct HTTP2TransportTLSEnabledTests {
       return .posix(config)
 
     case .transportServices:
-      var config = self.makeDefaultPlaintextTransportServicesServerConfig()
+      var config = self.makeDefaultPlaintextTSServerConfig()
       config.security = .mTLS {
         try self.makeSecIdentityProvider(
           certificateBytes: certificateKeyPairs.server.certificate,

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -99,7 +99,8 @@ struct HTTP2TransportTLSEnabledTests {
     let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
     let clientTransportConfig = self.makeDefaultTLSClientConfig(
       for: clientTransport,
-      certificateKeyPairs: certificateKeyPairs
+      certificateKeyPairs: certificateKeyPairs,
+      authority: nil
     )
     let serverTransportConfig = self.makeDefaultTLSServerConfig(
       for: serverTransport,
@@ -273,7 +274,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   private func makeDefaultTLSClientConfig(
     for transportSecurity: TransportKind,
-    certificateKeyPairs: SelfSignedCertificateKeyPairs
+    certificateKeyPairs: SelfSignedCertificateKeyPairs,
+    authority: String? = "localhost"
   ) -> ClientConfig {
     switch transportSecurity {
     case .posix:
@@ -283,8 +285,9 @@ struct HTTP2TransportTLSEnabledTests {
           .bytes(certificateKeyPairs.server.certificate, format: .der)
         ])
       }
-      config.transport.http2.authority = "localhost"
+      config.transport.http2.authority = authority
       return .posix(config)
+
     case .transportServices:
       var config = self.makeDefaultPlaintextTransportServicesClientConfig()
       config.security = .tls {
@@ -292,7 +295,7 @@ struct HTTP2TransportTLSEnabledTests {
           .bytes(certificateKeyPairs.server.certificate, format: .der)
         ])
       }
-      config.transport.http2.authority = "localhost"
+      config.transport.http2.authority = authority
       return .transportServices(config)
     }
   }
@@ -304,7 +307,7 @@ struct HTTP2TransportTLSEnabledTests {
     let password = "somepassword"
     let bundle = NIOSSLPKCS12Bundle(
       certificateChain: [try NIOSSLCertificate(bytes: certificateBytes, format: .der)],
-      privateKey: try NIOSSLPrivateKey(bytes: certificateBytes, format: .der)
+      privateKey: try NIOSSLPrivateKey(bytes: privateKeyBytes, format: .der)
     )
     let pkcs12Bytes = try bundle.serialize(passphrase: password.utf8)
     let options = [kSecImportExportPassphrase as String: password]

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -120,7 +120,7 @@ struct HTTP2TransportTLSEnabledTests {
         case .posix:
           #expect(
             rootError.message
-            == "The server accepted the TCP connection but closed the connection before completing the HTTP/2 connection preface."
+              == "The server accepted the TCP connection but closed the connection before completing the HTTP/2 connection preface."
           )
           let sslError = try #require(rootError.cause as? NIOSSLExtraError)
           guard sslError == .failedToValidateHostname else {

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/SelfSignedCertificateKeyPairs.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/SelfSignedCertificateKeyPairs.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import SwiftASN1
-import X509
 import Crypto
 import Foundation
+import SwiftASN1
+import X509
 
 struct SelfSignedCertificateKeyPairs {
   struct CertificateKeyPair {

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/SelfSignedCertificateKeyPairs.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/SelfSignedCertificateKeyPairs.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftASN1
+import X509
+import Crypto
+import Foundation
+
+struct SelfSignedCertificateKeyPairs {
+  struct CertificateKeyPair {
+    let certificate: [UInt8]
+    let key: [UInt8]
+  }
+
+  let server: CertificateKeyPair
+  let client: CertificateKeyPair
+
+  init() throws {
+    let server = try Self.makeSelfSignedDERCertificateAndPrivateKey(name: "Server Certificate")
+    let client = try Self.makeSelfSignedDERCertificateAndPrivateKey(name: "Client Certificate")
+
+    self.server = CertificateKeyPair(certificate: server.cert, key: server.key)
+    self.client = CertificateKeyPair(certificate: client.cert, key: client.key)
+  }
+
+  private static func makeSelfSignedDERCertificateAndPrivateKey(
+    name: String
+  ) throws -> (cert: [UInt8], key: [UInt8]) {
+    let swiftCryptoKey = P256.Signing.PrivateKey()
+    let key = Certificate.PrivateKey(swiftCryptoKey)
+    let subjectName = try DistinguishedName { CommonName(name) }
+    let issuerName = subjectName
+    let now = Date()
+    let extensions = try Certificate.Extensions {
+      Critical(
+        BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+      )
+      Critical(
+        KeyUsage(digitalSignature: true, keyCertSign: true)
+      )
+      Critical(
+        try ExtendedKeyUsage([.serverAuth, .clientAuth])
+      )
+      SubjectAlternativeNames([.dnsName("localhost")])
+    }
+    let certificate = try Certificate(
+      version: .v3,
+      serialNumber: Certificate.SerialNumber(),
+      publicKey: key.publicKey,
+      notValidBefore: now.addingTimeInterval(-60 * 60),
+      notValidAfter: now.addingTimeInterval(60 * 60 * 24 * 365),
+      issuer: issuerName,
+      subject: subjectName,
+      signatureAlgorithm: .ecdsaWithSHA256,
+      extensions: extensions,
+      issuerPrivateKey: key
+    )
+
+    var serializer = DER.Serializer()
+    try serializer.serialize(certificate)
+
+    let certBytes = serializer.serializedBytes
+    let keyBytes = try key.serializeAsPEM().derBytes
+    return (certBytes, keyBytes)
+  }
+}


### PR DESCRIPTION
Note: Some flakiness may be present on these tests. This should be fixed with https://github.com/apple/swift-nio-http2/pull/483, but we'll have to update the package version once a new version is tagged.