### PR TITLE
Remove '#if canImport(NIOSSL)'

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if canImport(NIOSSL)
+
 import NIOSSL
 
 extension NIOSSLSerializationFormats {
@@ -159,4 +159,3 @@ extension TLSConfiguration {
     self.applicationProtocols = ["grpc-exp", "h2"]
   }
 }
-#endif

--- a/Sources/GRPCNIOTransportHTTP2Posix/TLSConfig.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/TLSConfig.swift
@@ -146,12 +146,10 @@ extension HTTP2ServerTransport.Posix.Config {
     /// This connection is plaintext: no encryption will take place.
     public static let plaintext = Self(wrapped: .plaintext)
 
-    #if canImport(NIOSSL)
     /// This connection will use TLS.
     public static func tls(_ tls: TLS) -> Self {
       Self(wrapped: .tls(tls))
     }
-    #endif
   }
 
   public struct TLS: Sendable {
@@ -261,12 +259,10 @@ extension HTTP2ClientTransport.Posix.Config {
     /// This connection is plaintext: no encryption will take place.
     public static let plaintext = Self(wrapped: .plaintext)
 
-    #if canImport(NIOSSL)
     /// This connection will use TLS.
     public static func tls(_ tls: TLS) -> Self {
       Self(wrapped: .tls(tls))
     }
-    #endif
   }
 
   public struct TLS: Sendable {

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
@@ -17,11 +17,8 @@
 import GRPCCore
 import GRPCNIOTransportCore
 import GRPCNIOTransportHTTP2Posix
-import XCTest
-
-#if canImport(NIOSSL)
 import NIOSSL
-#endif
+import XCTest
 
 final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
@@ -191,7 +188,6 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
     XCTAssertEqual(grpcConfig.backoff, HTTP2ClientTransport.Config.Backoff.defaults)
   }
 
-  #if canImport(NIOSSL)
   static let samplePemCert = """
     -----BEGIN CERTIFICATE-----
     MIIGGzCCBAOgAwIBAgIJAJ/X0Fo0ynmEMA0GCSqGSIb3DQEBCwUAMIGjMQswCQYD
@@ -478,5 +474,4 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
     XCTAssertEqual(nioSSLTLSConfig.trustRoots, .default)
     XCTAssertEqual(nioSSLTLSConfig.applicationProtocols, ["grpc-exp", "h2"])
   }
-  #endif
 }


### PR DESCRIPTION
Motivation:

Forks of this transport to remove NIOSSL can be done by removing the Posix module rather then removing NIOSSL. This means we no longer need the can-imports for NIOSSL.

Modifications:

Remove all instances of '#if canImport(NIOSSL)'

Result:

Simpler code