### PR TITLE
Add more build settings to test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,7 +98,8 @@ let targets: [Target] = [
       .product(name: "NIOCore", package: "swift-nio"),
       .product(name: "NIOEmbedded", package: "swift-nio"),
       .product(name: "NIOTestUtils", package: "swift-nio"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 
   // NIOPosix variant of the HTTP/2 transports.
@@ -139,7 +140,8 @@ let targets: [Target] = [
       .target(name: "GRPCNIOTransportHTTP2"),
       .product(name: "X509", package: "swift-certificates"),
       .product(name: "NIOSSL", package: "swift-nio-ssl"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 ]
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -26,7 +26,7 @@ extension ClientConnectionEvent: Equatable {}
 extension ClientConnectionEvent.CloseReason: Equatable {}
 
 extension Connection.Event {
-  package static func == (lhs: Connection.Event, rhs: Connection.Event) -> Bool {
+  static func == (lhs: Connection.Event, rhs: Connection.Event) -> Bool {
     switch (lhs, rhs) {
     case (.connectSucceeded, .connectSucceeded),
       (.connectFailed, .connectFailed):
@@ -45,7 +45,7 @@ extension Connection.Event {
 }
 
 extension Connection.CloseReason {
-  package static func == (lhs: Connection.CloseReason, rhs: Connection.CloseReason) -> Bool {
+  static func == (lhs: Connection.CloseReason, rhs: Connection.CloseReason) -> Bool {
     switch (lhs, rhs) {
     case (.idleTimeout, .idleTimeout),
       (.keepaliveTimeout, .keepaliveTimeout),
@@ -63,7 +63,7 @@ extension Connection.CloseReason {
 }
 
 extension ClientConnectionEvent {
-  package static func == (lhs: ClientConnectionEvent, rhs: ClientConnectionEvent) -> Bool {
+  static func == (lhs: ClientConnectionEvent, rhs: ClientConnectionEvent) -> Bool {
     switch (lhs, rhs) {
     case (.ready, .ready):
       return true
@@ -76,7 +76,7 @@ extension ClientConnectionEvent {
 }
 
 extension ClientConnectionEvent.CloseReason {
-  package static func == (lhs: Self, rhs: Self) -> Bool {
+  static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.goAway(let lhsCode, let lhsMessage), .goAway(let rhsCode, let rhsMessage)):
       return lhsCode == rhsCode && lhsMessage == rhsMessage

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -2837,7 +2837,7 @@ extension XCTestCase {
 }
 
 extension GRPCStreamStateMachine.OnNextOutboundFrame {
-  public static func == (
+  static func == (
     lhs: GRPCStreamStateMachine.OnNextOutboundFrame,
     rhs: GRPCStreamStateMachine.OnNextOutboundFrame
   ) -> Bool {


### PR DESCRIPTION
Motivation:

The test targets don't set the same Swift as the library targets. There's no reason for them not to.

Modifications:

- Apply default settings to test targets.
- Fixup ACLs in test extensions

Result:

Test targets use Swift 6 language mode, explicit existential any, and internal imports by default