### PR TITLE
Fixup soundness checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,19 +12,9 @@ jobs:
     with:
       license_header_check_project_name: "gRPC"
 
-  swift-license-check:
-    name: Swift License Header Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Mark the workspace as safe
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - name: Run license check
-        run: |
-          ./dev/license-check.sh
+  grpc-soundness:
+    name: Soundness
+    uses: ./.github/workflows/soundness.yml
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -1,0 +1,19 @@
+name: Soundness
+
+on:
+  workflow_call:
+
+jobs:
+  swift-license-check:
+    name: Swift license headers check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Run license check
+        run: |
+          ./dev/license-check.sh

--- a/.licenseignore
+++ b/.licenseignore
@@ -7,6 +7,7 @@
 .mailmap
 .spi.yml
 .swift-format
+.swiftformatignore
 .editorconfig
 .github/*
 *.md

--- a/.swiftformatignore
+++ b/.swiftformatignore
@@ -1,0 +1,2 @@
+*.grpc.swift
+*.pb.swift

--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,0 +1,3 @@
+**/*.pb.swift
+**/*.grpc.swift
+dev/protos/upstream/**/*.proto


### PR DESCRIPTION
### Motivation:

* Tidy up soundness checks in GitHub UI.
* Ensure checks don't run on generated code.

### Modifications:

* Soundness checks are now nested in a re-usable workflow so they are grouped in the GitHub UI as in other gRPC repos.
* ignore generated `.pb.swift` and `.grpc.swift` files.

### Result:

Tidier, more appropriate checks.