### PR TITLE
Remove '@_exported import GRPCCore'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -138,6 +138,7 @@ let targets: [Target] = [
     name: "GRPCNIOTransportHTTP2Tests",
     dependencies: [
       .target(name: "GRPCNIOTransportHTTP2"),
+      .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "X509", package: "swift-certificates"),
       .product(name: "NIOSSL", package: "swift-nio-ssl"),
     ],

--- a/Sources/GRPCNIOTransportHTTP2/Exports.swift
+++ b/Sources/GRPCNIOTransportHTTP2/Exports.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@_exported import GRPCCore
 @_exported import GRPCNIOTransportCore
 @_exported import GRPCNIOTransportHTTP2Posix
 @_exported import GRPCNIOTransportHTTP2TransportServices

--- a/Sources/GRPCNIOTransportHTTP2Posix/Exports.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Exports.swift
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-@_exported import GRPCCore
 @_exported import GRPCNIOTransportCore

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Exports.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Exports.swift
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-@_exported import GRPCCore
 @_exported import GRPCNIOTransportCore

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -16,6 +16,7 @@
 
 import Crypto
 import Foundation
+import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import NIOSSL
 import SwiftASN1


### PR DESCRIPTION
Motivation:

We added '@_exported import GRPCCore' to transport modules to make it easier for users as it saves them from adding an import. On reflection we've our position on this has changed and the implicit dependency will likely make things less clear.

Modifications:

- Remove exported import of GRPCCore

Result:

More explicit dependencies