### PR TITLE
Pre-emptively fix sendability issues with the next NIO release

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -80,8 +80,12 @@ extension HTTP2ServerTransport {
         let serverChannel = try await ServerBootstrap(group: eventLoopGroup)
           .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
           .serverChannelInitializer { channel in
-            let quiescingHandler = serverQuiescingHelper.makeServerChannelHandler(channel: channel)
-            return channel.pipeline.addHandler(quiescingHandler)
+            return channel.eventLoop.makeCompletedFuture {
+              let quiescingHandler = serverQuiescingHelper.makeServerChannelHandler(
+                channel: channel
+              )
+              return try channel.pipeline.syncOperations.addHandler(quiescingHandler)
+            }
           }
           .bind(to: address) { channel in
             channel.eventLoop.makeCompletedFuture {

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -58,8 +58,12 @@ extension HTTP2ServerTransport {
           try await bootstrap
           .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
           .serverChannelInitializer { channel in
-            let quiescingHandler = serverQuiescingHelper.makeServerChannelHandler(channel: channel)
-            return channel.pipeline.addHandler(quiescingHandler)
+            return channel.eventLoop.makeCompletedFuture {
+              let quiescingHandler = serverQuiescingHelper.makeServerChannelHandler(
+                channel: channel
+              )
+              return try channel.pipeline.syncOperations.addHandler(quiescingHandler)
+            }
           }
           .bind(to: address) { channel in
             channel.eventLoop.makeCompletedFuture {


### PR DESCRIPTION
Motivation:

The next NIO release includes stricter sendability checks which result in compilation errors in Swift 6 language mode.

Modifications:

- Change where a handler is constructed

Result:

Compiles with the SwiftNIO on main