### PR TITLE
Ensure user-provieded metadata has lowercase keys

### DIFF
--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -659,7 +659,8 @@ extension GRPCStreamStateMachine {
     }
 
     for metadataPair in customMetadata {
-      headers.add(name: metadataPair.key, value: metadataPair.value.encoded())
+      // Lowercase the field names for user-provided metadata.
+      headers.add(name: metadataPair.key.lowercased(), value: metadataPair.value.encoded())
     }
 
     return headers
@@ -1248,7 +1249,8 @@ extension GRPCStreamStateMachine {
     }
 
     for metadataPair in customMetadata {
-      headers.add(name: metadataPair.key, value: metadataPair.value.encoded())
+      // Lowercase the field names for user-provided metadata.
+      headers.add(name: metadataPair.key.lowercased(), value: metadataPair.value.encoded())
     }
   }
 
@@ -1827,7 +1829,8 @@ extension HPACKHeaders {
     }
 
     for (key, value) in metadata {
-      trailers.add(name: key, value: value.encoded())
+      // Lowercase the field names for user-provided metadata.
+      trailers.add(name: key.lowercased(), value: value.encoded())
     }
   }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
@@ -64,6 +64,12 @@ struct ControlInput: Codable {
   /// removed (":path" should become "echo-path").
   var echoMetadataInTrailers: Bool = false
 
+  /// Key-value pairs to add to the initial metadata.
+  var initialMetadataToAdd: [String: String] = [:]
+
+  /// Key-value pairs to add to the trailing metadata.
+  var trailingMetadataToAdd: [String: String] = [:]
+
   struct Status: Codable {
     var code: GRPCCore.Status.Code
     var message: String


### PR DESCRIPTION
Motivation:

HTTP/2 requires header field names to be lowercased. Metadata keys should be lowercased automatically.

Modifications:

Lowercase user-provided metadata keys.

Results:

Fewer bugs