### PR TITLE
Use new descriptor API

### DIFF
--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -1757,7 +1757,7 @@ extension MethodDescriptor {
     view.formIndex(after: &index)
     let method = String(view[index...])
 
-    self.init(service: service, method: method)
+    self.init(service: ServiceDescriptor(fullyQualifiedService: service), method: method)
   }
 }
 

--- a/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
@@ -53,7 +53,10 @@ package struct MethodConfigs: Sendable, Hashable {
   ///  - descriptor: The ``MethodDescriptor`` for which to get or set a ``MethodConfig``.
   package subscript(_ descriptor: MethodDescriptor) -> MethodConfig? {
     get {
-      var name = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
+      var name = MethodConfig.Name(
+        service: descriptor.service.fullyQualifiedService,
+        method: descriptor.method
+      )
 
       if let configuration = self.elements[name] {
         return configuration
@@ -72,7 +75,10 @@ package struct MethodConfigs: Sendable, Hashable {
     }
 
     set {
-      let name = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
+      let name = MethodConfig.Name(
+        service: descriptor.service.fullyQualifiedService,
+        method: descriptor.method
+      )
       self.elements[name] = newValue
     }
   }

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -27,7 +27,7 @@ import XCTest
 final class GRPCClientStreamHandlerTests: XCTestCase {
   func testH2FramesAreIgnored() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -58,7 +58,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerInitialMetadataMissingHTTPStatusCodeResultsInFinishedRPC() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -94,7 +94,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerInitialMetadata1xxHTTPStatusCodeResultsInNothingRead() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -125,7 +125,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerInitialMetadataOtherNon200HTTPStatusCodeResultsInFinishedRPC() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -162,7 +162,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerInitialMetadataMissingContentTypeResultsInFinishedRPC() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -198,7 +198,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testNotAcceptedEncodingResultsInFinishedRPC() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .deflate,
       acceptedEncodings: [.deflate],
@@ -256,7 +256,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testOverMaximumPayloadSize() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -323,7 +323,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerSendsEOSWhenSendingMessage_ResultsInErrorStatus() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -391,7 +391,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testServerEndsStream() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -457,7 +457,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testNormalFlow() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -575,7 +575,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testReceiveMessageSplitAcrossMultipleBuffers() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -680,7 +680,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testSendMultipleMessagesInSingleBuffer() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -764,7 +764,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testUnexpectedStreamClose_ErrorFired() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -814,7 +814,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testUnexpectedStreamClose_ChannelInactive() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -860,7 +860,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
   func testUnexpectedStreamClose_ResetStreamFrame() throws {
     let handler = GRPCClientStreamHandler(
-      methodDescriptor: .init(service: "test", method: "test"),
+      methodDescriptor: .testTest,
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
@@ -938,4 +938,8 @@ extension EmbeddedChannel {
 
 private enum TestError: Error {
   case assertionFailure(String)
+}
+
+extension MethodDescriptor {
+  static let testTest = Self(fullyQualifiedService: "test", method: "test")
 }

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -143,7 +143,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     var stateMachine = GRPCStreamStateMachine(
       configuration: .client(
         .init(
-          methodDescriptor: .init(service: "test", method: "test"),
+          methodDescriptor: .testTest,
           scheme: .http,
           outboundEncoding: compressionEnabled ? .deflate : .none,
           acceptedEncodings: [.deflate]
@@ -1847,8 +1847,7 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
       ":method": "POST",
       "content-type": "application/grpc",
     ]
-    let descriptor = MethodDescriptor(service: "test", method: "test")
-    XCTAssertEqual(action, .receivedMetadata(metadata, descriptor))
+    XCTAssertEqual(action, .receivedMetadata(metadata, .testTest))
   }
 
   func testReceiveMetadataWhenClientIdleAndServerIdle_MissingMethod() throws {

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -763,7 +763,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     XCTAssertEqual(
       try promise.futureResult.wait(),
-      MethodDescriptor(service: "SomeService", method: "SomeMethod")
+      MethodDescriptor(fullyQualifiedService: "SomeService", method: "SomeMethod")
     )
   }
 

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
@@ -18,16 +18,19 @@ import GRPCCore
 
 extension MethodDescriptor {
   static var echoGet: Self {
-    MethodDescriptor(service: "echo.Echo", method: "Get")
+    MethodDescriptor(fullyQualifiedService: "echo.Echo", method: "Get")
   }
 
   static var echoUpdate: Self {
-    MethodDescriptor(service: "echo.Echo", method: "Update")
+    MethodDescriptor(fullyQualifiedService: "echo.Echo", method: "Update")
   }
 }
 
 extension MethodConfig.Name {
   init(_ descriptor: MethodDescriptor) {
-    self = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
+    self = MethodConfig.Name(
+      service: descriptor.service.fullyQualifiedService,
+      method: descriptor.method
+    )
   }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -33,7 +33,7 @@ internal struct ControlClient {
   ) async throws -> R where R: Sendable {
     try await self.client.unary(
       request: request,
-      descriptor: MethodDescriptor(service: "Control", method: "Unary"),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "Unary"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,
@@ -48,7 +48,7 @@ internal struct ControlClient {
   ) async throws -> R where R: Sendable {
     try await self.client.serverStreaming(
       request: request,
-      descriptor: MethodDescriptor(service: "Control", method: "ServerStream"),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "ServerStream"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,
@@ -66,7 +66,7 @@ internal struct ControlClient {
   ) async throws -> R where R: Sendable {
     try await self.client.clientStreaming(
       request: request,
-      descriptor: MethodDescriptor(service: "Control", method: "ClientStream"),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "ClientStream"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,
@@ -81,7 +81,7 @@ internal struct ControlClient {
   ) async throws -> R where R: Sendable {
     try await self.client.bidirectionalStreaming(
       request: request,
-      descriptor: MethodDescriptor(service: "Control", method: "BidiStream"),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "BidiStream"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,
@@ -98,7 +98,7 @@ internal struct ControlClient {
   ) async throws -> R where R: Sendable {
     try await self.client.serverStreaming(
       request: request,
-      descriptor: MethodDescriptor(service: "Control", method: "WaitForCancellation"),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "WaitForCancellation"),
       serializer: JSONSerializer(),
       deserializer: JSONDeserializer(),
       options: options,

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -20,7 +20,7 @@ import GRPCCore
 struct ControlService: RegistrableRPCService {
   func registerMethods(with router: inout RPCRouter) {
     router.registerHandler(
-      forMethod: MethodDescriptor(service: "Control", method: "Unary"),
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "Unary"),
       deserializer: JSONDeserializer<ControlInput>(),
       serializer: JSONSerializer<ControlOutput>(),
       handler: { request, context in
@@ -28,7 +28,7 @@ struct ControlService: RegistrableRPCService {
       }
     )
     router.registerHandler(
-      forMethod: MethodDescriptor(service: "Control", method: "ServerStream"),
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "ServerStream"),
       deserializer: JSONDeserializer<ControlInput>(),
       serializer: JSONSerializer<ControlOutput>(),
       handler: { request, context in
@@ -36,7 +36,7 @@ struct ControlService: RegistrableRPCService {
       }
     )
     router.registerHandler(
-      forMethod: MethodDescriptor(service: "Control", method: "ClientStream"),
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "ClientStream"),
       deserializer: JSONDeserializer<ControlInput>(),
       serializer: JSONSerializer<ControlOutput>(),
       handler: { request, context in
@@ -44,7 +44,7 @@ struct ControlService: RegistrableRPCService {
       }
     )
     router.registerHandler(
-      forMethod: MethodDescriptor(service: "Control", method: "BidiStream"),
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "BidiStream"),
       deserializer: JSONDeserializer<ControlInput>(),
       serializer: JSONSerializer<ControlOutput>(),
       handler: { request, context in
@@ -52,7 +52,7 @@ struct ControlService: RegistrableRPCService {
       }
     )
     router.registerHandler(
-      forMethod: MethodDescriptor(service: "Control", method: "WaitForCancellation"),
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "WaitForCancellation"),
       deserializer: JSONDeserializer<CancellationKind>(),
       serializer: JSONSerializer<Empty>(),
       handler: { request, context in


### PR DESCRIPTION
Motivation:

GRPCCore changed some of the descriptor API.

Modifications:

- Use the new API

Result:

- Compiles again
- No warnings