### PR TITLE
Propagate the authority pseudoheader

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
@@ -19,6 +19,11 @@ package import NIOHTTP2
 internal import NIOPosix
 
 package protocol HTTP2Connector: Sendable {
+  /// Attempt to establish a connection to the given address.
+  ///
+  /// - Parameters:
+  ///   - address: The address to connect to.
+  ///   - authority: The authority as used for the TLS SNI extension (if applicable).
   func establishConnection(
     to address: SocketAddress,
     authority: String?

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
@@ -19,7 +19,10 @@ package import NIOHTTP2
 internal import NIOPosix
 
 package protocol HTTP2Connector: Sendable {
-  func establishConnection(to address: SocketAddress) async throws -> HTTP2Connection
+  func establishConnection(
+    to address: SocketAddress,
+    authority: String?
+  ) async throws -> HTTP2Connection
 }
 
 package struct HTTP2Connection: Sendable {

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -52,8 +52,8 @@ package final class GRPCChannel: ClientTransport {
   /// A factory for connections.
   private let connector: any HTTP2Connector
 
-  /// The server authority. If `nil`, a value will be computed based on the endpoint being
-  /// connected to.
+  /// The percent-encoded server authority. If `nil`, a value will be computed based on the endpoint
+  /// being connected to.
   private let authority: String?
 
   /// The connection backoff configuration used by the subchannel when establishing a connection.
@@ -86,6 +86,9 @@ package final class GRPCChannel: ClientTransport {
     self.input = AsyncStream.makeStream()
     self.connector = connector
 
+    // Determine the authority to use for the ":authority" pseudo-header and in the TLS SNI
+    // extension. This value will be used for all subchannels and connections. If no authority
+    // is set then one will be derived for each address being connected to.
     if let authority = config.http2.authority ?? resolver.authority {
       self.authority = PercentEncoding.encodeAuthority(authority)
     } else {

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -77,6 +77,10 @@ package final class PickFirstLoadBalancer: Sendable {
   /// A connector, capable of creating connections.
   private let connector: any HTTP2Connector
 
+  /// The server authority. If `nil`, a value will be computed based on the endpoint being
+  /// connected to.
+  private let authority: String?
+
   /// Connection backoff configuration.
   private let backoff: ConnectionBackoff
 
@@ -94,11 +98,13 @@ package final class PickFirstLoadBalancer: Sendable {
 
   package init(
     connector: any HTTP2Connector,
+    authority: String?,
     backoff: ConnectionBackoff,
     defaultCompression: CompressionAlgorithm,
     enabledCompression: CompressionAlgorithmSet
   ) {
     self.connector = connector
+    self.authority = authority
     self.backoff = backoff
     self.defaultCompression = defaultCompression
     self.enabledCompression = enabledCompression
@@ -174,6 +180,7 @@ extension PickFirstLoadBalancer {
           endpoint: endpoint,
           id: id,
           connector: self.connector,
+          authority: self.authority,
           backoff: self.backoff,
           defaultCompression: self.defaultCompression,
           enabledCompression: self.enabledCompression

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -77,8 +77,8 @@ package final class PickFirstLoadBalancer: Sendable {
   /// A connector, capable of creating connections.
   private let connector: any HTTP2Connector
 
-  /// The server authority. If `nil`, a value will be computed based on the endpoint being
-  /// connected to.
+  /// The percent-encoded server authority. If `nil`, a value will be computed based on the endpoint
+  /// being connected to.
   private let authority: String?
 
   /// Connection backoff configuration.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -109,6 +109,10 @@ package final class RoundRobinLoadBalancer: Sendable {
   /// A connector, capable of creating connections.
   private let connector: any HTTP2Connector
 
+  /// The server authority. If `nil`, a value will be computed based on the endpoint being
+  /// connected to.
+  private let authority: String?
+
   /// Connection backoff configuration.
   private let backoff: ConnectionBackoff
 
@@ -123,11 +127,13 @@ package final class RoundRobinLoadBalancer: Sendable {
 
   package init(
     connector: any HTTP2Connector,
+    authority: String?,
     backoff: ConnectionBackoff,
     defaultCompression: CompressionAlgorithm,
     enabledCompression: CompressionAlgorithmSet
   ) {
     self.connector = connector
+    self.authority = authority
     self.backoff = backoff
     self.defaultCompression = defaultCompression
     self.enabledCompression = enabledCompression
@@ -223,6 +229,7 @@ extension RoundRobinLoadBalancer {
           endpoint: endpoint,
           id: id,
           connector: self.connector,
+          authority: self.authority,
           backoff: self.backoff,
           defaultCompression: self.defaultCompression,
           enabledCompression: self.enabledCompression

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -109,8 +109,8 @@ package final class RoundRobinLoadBalancer: Sendable {
   /// A connector, capable of creating connections.
   private let connector: any HTTP2Connector
 
-  /// The server authority. If `nil`, a value will be computed based on the endpoint being
-  /// connected to.
+  /// The percent-encoded server authority. If `nil`, a value will be computed based on the endpoint
+  /// being connected to.
   private let authority: String?
 
   /// Connection backoff configuration.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -83,6 +83,10 @@ package final class Subchannel: Sendable {
   /// A factory for connections.
   private let connector: any HTTP2Connector
 
+  /// The server authority. If `nil`, a value will be computed based on the endpoint being
+  /// connected to.
+  private let authority: String?
+
   /// The connection backoff configuration used by the subchannel when establishing a connection.
   private let backoff: ConnectionBackoff
 
@@ -96,6 +100,7 @@ package final class Subchannel: Sendable {
     endpoint: Endpoint,
     id: SubchannelID,
     connector: any HTTP2Connector,
+    authority: String?,
     backoff: ConnectionBackoff,
     defaultCompression: CompressionAlgorithm,
     enabledCompression: CompressionAlgorithmSet
@@ -106,6 +111,7 @@ package final class Subchannel: Sendable {
     self.endpoint = endpoint
     self.id = id
     self.connector = connector
+    self.authority = authority
     self.backoff = backoff
     self.defaultCompression = defaultCompression
     self.enabledCompression = enabledCompression
@@ -194,6 +200,7 @@ extension Subchannel {
       state.makeConnection(
         to: self.endpoint.addresses,
         using: self.connector,
+        authority: self.authority,
         backoff: self.backoff,
         defaultCompression: self.defaultCompression,
         enabledCompression: self.enabledCompression
@@ -283,7 +290,10 @@ extension Subchannel {
   }
 
   private func handleConnectFailedEvent(in group: inout DiscardingTaskGroup, error: RPCError) {
-    let onConnectFailed = self.state.withLock { $0.connectFailed(connector: self.connector) }
+    let onConnectFailed = self.state.withLock {
+      $0.connectFailed(connector: self.connector, authority: self.authority)
+    }
+
     switch onConnectFailed {
     case .connect(let connection):
       // Try the next address.
@@ -469,6 +479,7 @@ extension Subchannel {
     mutating func makeConnection(
       to addresses: [SocketAddress],
       using connector: any HTTP2Connector,
+      authority: String?,
       backoff: ConnectionBackoff,
       defaultCompression: CompressionAlgorithm,
       enabledCompression: CompressionAlgorithmSet
@@ -480,6 +491,7 @@ extension Subchannel {
 
         let connection = Connection(
           address: address,
+          authority: authority,
           http2Connector: connector,
           defaultCompression: defaultCompression,
           enabledCompression: enabledCompression
@@ -563,7 +575,10 @@ extension Subchannel {
       case backoff(Duration)
     }
 
-    mutating func connectFailed(connector: any HTTP2Connector) -> OnConnectFailed {
+    mutating func connectFailed(
+      connector: any HTTP2Connector,
+      authority: String?
+    ) -> OnConnectFailed {
       let onConnectFailed: OnConnectFailed
 
       switch self {
@@ -571,6 +586,7 @@ extension Subchannel {
         if let address = state.addressIterator.next() {
           state.connection = Connection(
             address: address,
+            authority: authority,
             http2Connector: connector,
             defaultCompression: .none,
             enabledCompression: .all
@@ -582,6 +598,7 @@ extension Subchannel {
           let address = state.addressIterator.next()!
           state.connection = Connection(
             address: address,
+            authority: authority,
             http2Connector: connector,
             defaultCompression: .none,
             enabledCompression: .all

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -83,8 +83,8 @@ package final class Subchannel: Sendable {
   /// A factory for connections.
   private let connector: any HTTP2Connector
 
-  /// The server authority. If `nil`, a value will be computed based on the endpoint being
-  /// connected to.
+  /// The percent-encoded server authority. If `nil`, a value will be computed based on the endpoint
+  /// being connected to.
   private let authority: String?
 
   /// The connection backoff configuration used by the subchannel when establishing a connection.

--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -33,6 +33,7 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
   init(
     methodDescriptor: MethodDescriptor,
     scheme: Scheme,
+    authority: String?,
     outboundEncoding: CompressionAlgorithm,
     acceptedEncodings: CompressionAlgorithmSet,
     maxPayloadSize: Int,
@@ -43,6 +44,7 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
         .init(
           methodDescriptor: methodDescriptor,
           scheme: scheme,
+          authority: authority,
           outboundEncoding: outboundEncoding,
           acceptedEncodings: acceptedEncodings
         )

--- a/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
@@ -144,15 +144,24 @@ extension HTTP2ClientTransport.Config {
     /// The value is clamped to `... (1 << 31) - 1`.
     public var targetWindowSize: Int
 
+    /// The authority of the server.
+    ///
+    /// Any value set here will unconditionally override any value derived from the target address.
+    ///
+    /// The server authority is used in the ":authority" pseudoheader and in the TLS SNI
+    /// extension, if applicable.
+    public var authority: String?
+
     /// Creates a new HTTP/2 configuration.
-    public init(maxFrameSize: Int, targetWindowSize: Int) {
+    public init(maxFrameSize: Int, targetWindowSize: Int, authority: String?) {
       self.maxFrameSize = maxFrameSize
       self.targetWindowSize = targetWindowSize
+      self.authority = authority
     }
 
     /// Default values, max frame size is 16KiB, and the target window size is 8MiB.
     public static var defaults: Self {
-      Self(maxFrameSize: 1 << 14, targetWindowSize: 8 * 1024 * 1024)
+      Self(maxFrameSize: 1 << 14, targetWindowSize: 8 * 1024 * 1024, authority: nil)
     }
   }
 }

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
@@ -25,18 +25,32 @@ extension ResolvableTargets {
     /// The Unix Domain Socket address.
     public var address: SocketAddress.UnixDomainSocket
 
+    /// The authority of the service.
+    ///
+    /// If unset then the path of the address will be used.
+    public var authority: String?
+
     /// Create a new Unix Domain Socket address.
-    public init(address: SocketAddress.UnixDomainSocket) {
+    public init(address: SocketAddress.UnixDomainSocket, authority: String?) {
       self.address = address
+      self.authority = authority
     }
   }
 }
 
 extension ResolvableTarget where Self == ResolvableTargets.UnixDomainSocket {
   /// Creates a new resolvable Unix Domain Socket target.
-  /// - Parameter path: The path of the socket.
-  public static func unixDomainSocket(path: String) -> Self {
-    return Self(address: SocketAddress.UnixDomainSocket(path: path))
+  /// - Parameters
+  ///   - path: The path of the socket.
+  ///   - authority: The service authority.
+  public static func unixDomainSocket(
+    path: String,
+    authority: String? = nil
+  ) -> Self {
+    return Self(
+      address: SocketAddress.UnixDomainSocket(path: path),
+      authority: authority
+    )
   }
 }
 
@@ -53,7 +67,11 @@ extension NameResolvers {
     public func resolver(for target: Target) -> NameResolver {
       let endpoint = Endpoint(addresses: [.unixDomainSocket(target.address)])
       let resolutionResult = NameResolutionResult(endpoints: [endpoint], serviceConfig: nil)
-      return NameResolver(names: .constant(resolutionResult), updateMode: .pull)
+      return NameResolver(
+        names: .constant(resolutionResult),
+        updateMode: .pull,
+        authority: target.authority ?? target.address.path
+      )
     }
   }
 }

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
@@ -31,6 +31,9 @@ public struct NameResolver: Sendable {
   /// How ``names`` is updated and should be consumed.
   public let updateMode: UpdateMode
 
+  /// The authority of the service.
+  public let authority: String?
+
   public struct UpdateMode: Hashable, Sendable {
     enum Value: Hashable, Sendable {
       case push
@@ -51,9 +54,14 @@ public struct NameResolver: Sendable {
   }
 
   /// Create a new name resolver.
-  public init(names: RPCAsyncSequence<NameResolutionResult, any Error>, updateMode: UpdateMode) {
+  public init(
+    names: RPCAsyncSequence<NameResolutionResult, any Error>,
+    updateMode: UpdateMode,
+    authority: String? = nil
+  ) {
     self.names = names
     self.updateMode = updateMode
+    self.authority = authority
   }
 }
 

--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -31,17 +31,20 @@ enum GRPCStreamStateMachineConfiguration {
   struct ClientConfiguration {
     var methodDescriptor: MethodDescriptor
     var scheme: Scheme
+    var authority: String?
     var outboundEncoding: CompressionAlgorithm
     var acceptedEncodings: CompressionAlgorithmSet
 
     init(
       methodDescriptor: MethodDescriptor,
       scheme: Scheme,
+      authority: String?,
       outboundEncoding: CompressionAlgorithm,
       acceptedEncodings: CompressionAlgorithmSet
     ) {
       self.methodDescriptor = methodDescriptor
       self.scheme = scheme
+      self.authority = authority
       self.outboundEncoding = outboundEncoding
       self.acceptedEncodings = acceptedEncodings.union(.none)
     }
@@ -630,6 +633,7 @@ extension GRPCStreamStateMachine {
   private func makeClientHeaders(
     methodDescriptor: MethodDescriptor,
     scheme: Scheme,
+    authority: String?,
     outboundEncoding: CompressionAlgorithm?,
     acceptedEncodings: CompressionAlgorithmSet,
     customMetadata: Metadata
@@ -645,6 +649,9 @@ extension GRPCStreamStateMachine {
     headers.add("POST", forKey: .method)
     headers.add(scheme.rawValue, forKey: .scheme)
     headers.add(methodDescriptor.path, forKey: .path)
+    if let authority = authority {
+      headers.add(authority, forKey: .authority)
+    }
 
     // Add required gRPC headers.
     headers.add(ContentType.grpc.canonicalValue, forKey: .contentType)
@@ -690,6 +697,7 @@ extension GRPCStreamStateMachine {
       return self.makeClientHeaders(
         methodDescriptor: configuration.methodDescriptor,
         scheme: configuration.scheme,
+        authority: configuration.authority,
         outboundEncoding: configuration.outboundEncoding,
         acceptedEncodings: configuration.acceptedEncodings,
         customMetadata: metadata
@@ -1764,6 +1772,7 @@ extension MethodDescriptor {
 }
 
 internal enum GRPCHTTP2Keys: String {
+  case authority = ":authority"
   case path = ":path"
   case contentType = "content-type"
   case encoding = "grpc-encoding"

--- a/Sources/GRPCNIOTransportCore/Internal/PercentEncoding.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/PercentEncoding.swift
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package enum PercentEncoding {
+  package static func encodeAuthority(_ input: String) -> String {
+    Self.encode(input) {
+      Self.isAuthorityChar($0)
+    }
+  }
+
+  package static func encode(
+    _ input: String,
+    isValidCharacter: (UInt8) -> Bool
+  ) -> String {
+    var output: [UInt8] = []
+    output.reserveCapacity(input.utf8.count)
+
+    for char in input.utf8 {
+      if isValidCharacter(char) {
+        output.append(char)
+      } else {
+        output.append(UInt8(ascii: "%"))
+        output.append(Self.hexByte(char >> 4))
+        output.append(Self.hexByte(char & 0xF))
+      }
+    }
+
+    return String(decoding: output, as: UTF8.self)
+  }
+
+  private static func hexByte(_ nibble: UInt8) -> UInt8 {
+    assert(nibble & 0xF == nibble)
+
+    switch nibble {
+    case 0 ... 9:
+      return nibble &+ UInt8(ascii: "0")
+    default:
+      return nibble &+ (UInt8(ascii: "A") &- 10)
+    }
+  }
+
+  // Characters from RFC 3986 § 2.2
+  private static func isAlphaNumericChar(_ char: UInt8) -> Bool {
+    switch char {
+    case UInt8(ascii: "a") ... UInt8(ascii: "z"):
+      return true
+    case UInt8(ascii: "A") ... UInt8(ascii: "Z"):
+      return true
+    case UInt8(ascii: "0") ... UInt8(ascii: "9"):
+      return true
+    default:
+      return false
+    }
+  }
+
+  // Characters from RFC 3986 § 2.2
+  private static func isSubDelimChar(_ char: UInt8) -> Bool {
+    switch char {
+    case UInt8(ascii: "!"):
+      return true
+    case UInt8(ascii: "$"):
+      return true
+    case UInt8(ascii: "&"):
+      return true
+    case UInt8(ascii: "'"):
+      return true
+    case UInt8(ascii: "("):
+      return true
+    case UInt8(ascii: ")"):
+      return true
+    case UInt8(ascii: "*"):
+      return true
+    case UInt8(ascii: "+"):
+      return true
+    case UInt8(ascii: ","):
+      return true
+    case UInt8(ascii: ";"):
+      return true
+    case UInt8(ascii: "="):
+      return true
+    default:
+      return false
+    }
+  }
+
+  // Characters from RFC 3986 § 2.3
+  private static func isUnreservedChar(_ char: UInt8) -> Bool {
+    if Self.isAlphaNumericChar(char) { return true }
+
+    switch char {
+    case UInt8(ascii: "-"):
+      return true
+    case UInt8(ascii: "."):
+      return true
+    case UInt8(ascii: "_"):
+      return true
+    case UInt8(ascii: "~"):
+      return true
+    default:
+      return false
+    }
+  }
+
+  // Characters from RFC 3986 § 3.2
+  private static func isAuthorityChar(_ char: UInt8) -> Bool {
+    if Self.isUnreservedChar(char) { return true }
+    if Self.isSubDelimChar(char) { return true }
+
+    switch char {
+    case UInt8(ascii: ":"):
+      return true
+    case UInt8(ascii: "["):
+      return true
+    case UInt8(ascii: "]"):
+      return true
+    case UInt8(ascii: "@"):
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
@@ -159,28 +159,22 @@ extension HTTP2ClientTransport.Posix.Config {
     /// The trust roots to be used when verifying server certificates.
     public var trustRoots: TLSConfig.TrustRootsSource
 
-    /// An optional server hostname to use when verifying certificates.
-    public var serverHostname: String?
-
     /// Create a new HTTP2 NIO Posix client transport TLS config.
     /// - Parameters:
     ///   - certificateChain: The certificates the client will offer during negotiation.
     ///   - privateKey: The private key associated with the leaf certificate.
     ///   - serverCertificateVerification: How to verify the server certificate, if one is presented.
     ///   - trustRoots: The trust roots to be used when verifying server certificates.
-    ///   - serverHostname: An optional server hostname to use when verifying certificates.
     public init(
       certificateChain: [TLSConfig.CertificateSource],
       privateKey: TLSConfig.PrivateKeySource?,
       serverCertificateVerification: TLSConfig.CertificateVerification,
-      trustRoots: TLSConfig.TrustRootsSource,
-      serverHostname: String?
+      trustRoots: TLSConfig.TrustRootsSource
     ) {
       self.certificateChain = certificateChain
       self.privateKey = privateKey
       self.serverCertificateVerification = serverCertificateVerification
       self.trustRoots = trustRoots
-      self.serverHostname = serverHostname
     }
 
     /// Create a new HTTP2 NIO Posix transport TLS config, with some values defaulted:
@@ -188,7 +182,6 @@ extension HTTP2ClientTransport.Posix.Config {
     /// - `privateKey` equals `nil`
     /// - `serverCertificateVerification` equals `fullVerification`
     /// - `trustRoots` equals `systemDefault`
-    /// - `serverHostname` equals `nil`
     ///
     /// - Parameters:
     ///   - configure: A closure which allows you to modify the defaults before returning them.
@@ -200,8 +193,7 @@ extension HTTP2ClientTransport.Posix.Config {
         certificateChain: [],
         privateKey: nil,
         serverCertificateVerification: .fullVerification,
-        trustRoots: .systemDefault,
-        serverHostname: nil
+        trustRoots: .systemDefault
       )
       configure(&config)
       return config
@@ -212,14 +204,12 @@ extension HTTP2ClientTransport.Posix.Config {
     /// - `privateKey` equals `nil`
     /// - `serverCertificateVerification` equals `fullVerification`
     /// - `trustRoots` equals `systemDefault`
-    /// - `serverHostname` equals `nil`
     public static var defaults: Self { .defaults() }
 
     /// Create a new HTTP2 NIO Posix transport TLS config, with some values defaulted to match
     /// the requirements of mTLS:
     /// - `trustRoots` equals `systemDefault`
     /// - `serverCertificateVerification` equals `fullVerification`
-    /// - `serverHostname` equals `nil`
     ///
     /// - Parameters:
     ///   - certificateChain: The certificates the client will offer during negotiation.
@@ -235,8 +225,7 @@ extension HTTP2ClientTransport.Posix.Config {
         certificateChain: certificateChain,
         privateKey: privateKey,
         serverCertificateVerification: .fullVerification,
-        trustRoots: .systemDefault,
-        serverHostname: nil
+        trustRoots: .systemDefault
       )
       configure(&config)
       return config

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
@@ -148,9 +148,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
     /// - Important: If specifying custom certificates, they must be DER-encoded X509 certificates.
     public var trustRoots: TLSConfig.TrustRootsSource
 
-    /// An optional server hostname to use when verifying certificates.
-    public var serverHostname: String?
-
     /// An optional provider for the `SecIdentity` to be used when setting up TLS.
     public var identityProvider: (@Sendable () throws -> SecIdentity)?
 
@@ -158,16 +155,13 @@ extension HTTP2ClientTransport.TransportServices.Config {
     /// - Parameters:
     ///   - serverCertificateVerification: How to verify the server certificate, if one is presented.
     ///   - trustRoots: The trust roots to be used when verifying server certificates.
-    ///   - serverHostname: An optional server hostname to use when verifying certificates.
     ///   - identityProvider: A provider for the `SecIdentity` to be used when setting up TLS.
     public init(
       serverCertificateVerification: TLSConfig.CertificateVerification,
       trustRoots: TLSConfig.TrustRootsSource,
-      serverHostname: String?,
       identityProvider: (@Sendable () throws -> SecIdentity)?
     ) {
       self.serverCertificateVerification = serverCertificateVerification
-      self.serverHostname = serverHostname
       self.trustRoots = trustRoots
       self.identityProvider = identityProvider
     }
@@ -175,7 +169,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
     /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted:
     /// - `serverCertificateVerification` equals `fullVerification`
     /// - `trustRoots` equals `systemDefault`
-    /// - `serverHostname` equals `nil`
     /// - `identityProvider` equals `nil`
     ///
     /// - Parameters:
@@ -187,7 +180,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
       var config = Self(
         serverCertificateVerification: .fullVerification,
         trustRoots: .systemDefault,
-        serverHostname: nil,
         identityProvider: nil
       )
       configure(&config)
@@ -197,7 +189,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
     /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted:
     /// - `serverCertificateVerification` equals `fullVerification`
     /// - `trustRoots` equals `systemDefault`
-    /// - `serverHostname` equals `nil`
     /// - `identityProvider` equals `nil`
     public static var defaults: Self { .defaults() }
 
@@ -205,7 +196,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
     /// the requirements of mTLS:
     /// - `serverCertificateVerification` equals `fullVerification`
     /// - `trustRoots` equals `systemDefault`
-    /// - `serverHostname` equals `nil`
     ///
     /// - Parameters:
     ///   - identityProvider: A provider for the `SecIdentity` to be used when setting up TLS.
@@ -218,7 +208,6 @@ extension HTTP2ClientTransport.TransportServices.Config {
       var config = Self(
         serverCertificateVerification: .fullVerification,
         trustRoots: .systemDefault,
-        serverHostname: nil,
         identityProvider: identityProvider
       )
       configure(&config)

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -187,6 +187,7 @@ final class ConnectionTests: XCTestCase {
   func testMakeStreamOnNotRunningConnection() async throws {
     let connection = Connection(
       address: .ipv4(host: "ignored", port: 0),
+      authority: "ignored",
       http2Connector: .never,
       defaultCompression: .none,
       enabledCompression: .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
@@ -41,6 +41,7 @@ enum LoadBalancerTest {
     ) {
       let pickFirst = PickFirstLoadBalancer(
         connector: connector,
+        authority: nil,
         backoff: backoff,
         defaultCompression: .none,
         enabledCompression: .none
@@ -67,6 +68,7 @@ enum LoadBalancerTest {
     ) {
       let roundRobin = RoundRobinLoadBalancer(
         connector: connector,
+        authority: nil,
         backoff: backoff,
         defaultCompression: .none,
         enabledCompression: .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -297,6 +297,7 @@ final class RoundRobinLoadBalancerTests: XCTestCase {
   func testPickSubchannelWhenNotReady() {
     let loadBalancer = RoundRobinLoadBalancer(
       connector: .never,
+      authority: "ignored",
       backoff: .defaults,
       defaultCompression: .none,
       enabledCompression: .none
@@ -308,6 +309,7 @@ final class RoundRobinLoadBalancerTests: XCTestCase {
   func testPickSubchannelWhenClosed() async {
     let loadBalancer = RoundRobinLoadBalancer(
       connector: .never,
+      authority: "ignored",
       backoff: .defaults,
       defaultCompression: .none,
       enabledCompression: .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -568,6 +568,7 @@ final class SubchannelTests: XCTestCase {
       endpoint: Endpoint(addresses: addresses),
       id: SubchannelID(),
       connector: connector,
+      authority: nil,
       backoff: backoff ?? .defaults,
       defaultCompression: .none,
       enabledCompression: .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -42,6 +42,7 @@ enum ConnectionTest {
     try await withThrowingTaskGroup(of: Void.self) { group in
       let connection = Connection(
         address: address,
+        authority: nil,
         http2Connector: connector,
         defaultCompression: .none,
         enabledCompression: .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
@@ -61,7 +61,8 @@ struct ThrowingConnector: HTTP2Connector {
   }
 
   func establishConnection(
-    to address: GRPCNIOTransportCore.SocketAddress
+    to address: GRPCNIOTransportCore.SocketAddress,
+    authority: String?
   ) async throws -> HTTP2Connection {
     throw self.error
   }
@@ -69,7 +70,8 @@ struct ThrowingConnector: HTTP2Connector {
 
 struct NeverConnector: HTTP2Connector {
   func establishConnection(
-    to address: GRPCNIOTransportCore.SocketAddress
+    to address: GRPCNIOTransportCore.SocketAddress,
+    authority: String?
   ) async throws -> HTTP2Connection {
     fatalError("\(#function) called unexpectedly")
   }
@@ -100,7 +102,8 @@ struct NIOPosixConnector: HTTP2Connector {
   }
 
   func establishConnection(
-    to address: GRPCNIOTransportCore.SocketAddress
+    to address: GRPCNIOTransportCore.SocketAddress,
+    authority: String?
   ) async throws -> HTTP2Connection {
     return try await ClientBootstrap(group: self.eventLoopGroup).connect(to: address) { channel in
       channel.eventLoop.makeCompletedFuture {

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -29,6 +29,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1
@@ -60,6 +61,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -96,6 +98,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -127,6 +130,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -164,6 +168,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -200,6 +205,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .deflate,
       acceptedEncodings: [.deflate],
       maxPayloadSize: 1
@@ -258,6 +264,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -325,6 +332,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 100,
@@ -393,6 +401,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -459,6 +468,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 100,
@@ -577,6 +587,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 100,
@@ -682,6 +693,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 100,
@@ -766,6 +778,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -816,6 +829,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,
@@ -862,6 +876,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let handler = GRPCClientStreamHandler(
       methodDescriptor: .testTest,
       scheme: .http,
+      authority: nil,
       outboundEncoding: .none,
       acceptedEncodings: [],
       maxPayloadSize: 1,

--- a/Tests/GRPCNIOTransportCoreTests/Client/Resolver/SocketAddressTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Resolver/SocketAddressTests.swift
@@ -77,4 +77,18 @@ final class SocketAddressTests: XCTestCase {
     vsock.port = .any
     XCTAssertDescription(vsock, "[vsock]-1:-1")
   }
+
+  func testAuthority() {
+    var address: SocketAddress = .ipv4(host: "127.0.0.1", port: 42)
+    XCTAssertEqual(address.authority, "127.0.0.1:42")
+
+    address = .ipv6(host: "::1", port: 42)
+    XCTAssertEqual(address.authority, "[::1]:42")
+
+    address = .unixDomainSocket(path: "foo")
+    XCTAssertEqual(address.authority, "foo")
+
+    address = .vsock(contextID: 42, port: 8000)
+    XCTAssertEqual(address.authority, "42:8000")
+  }
 }

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -145,6 +145,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
         .init(
           methodDescriptor: .testTest,
           scheme: .http,
+          authority: nil,
           outboundEncoding: compressionEnabled ? .deflate : .none,
           acceptedEncodings: [.deflate]
         )

--- a/Tests/GRPCNIOTransportCoreTests/Internal/PercentEncodingTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/PercentEncodingTests.swift
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCNIOTransportCore
+import Testing
+
+@Suite("Percent encoding")
+struct PercentEncodingTests {
+  @Test(
+    "encode ':authority'",
+    arguments: [
+      ("", ""),
+      ("foo", "foo"),
+      ("FOO", "FOO"),
+      ("f00", "f00"),
+      ("f0&", "f0&"),
+      ("f**", "f**"),
+      ("fo#", "fo%23"),
+      ("fo/o|bar", "fo%2Fo%7Cbar"),
+      ("foo?bar", "foo%3Fbar"),
+      ("foo<bar>", "foo%3Cbar%3E"),
+    ]
+  )
+  func encodeAuthority(_ input: String, expected: String) {
+    let encoded = PercentEncoding.encodeAuthority(input)
+    #expect(encoded == expected)
+  }
+}

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -229,7 +229,6 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     XCTAssertEqual(grpcConfig.backoff, HTTP2ClientTransport.Config.Backoff.defaults)
 
     XCTAssertNil(grpcTLSConfig.identityProvider)
-    XCTAssertNil(grpcTLSConfig.serverHostname)
     XCTAssertEqual(grpcTLSConfig.serverCertificateVerification, .fullVerification)
     XCTAssertEqual(grpcTLSConfig.trustRoots, .systemDefault)
   }


### PR DESCRIPTION
Motivation:

We should be sending the ":authority" pseudoheader, somehow this was missed when doing the stream state machine.

The strategy for propagating the authority will be to:
- Use any override value set on the client transport, otherwise
- Use the value provided by a name resolver (if any), otherwise
- Derive a value from the target address.

Modifications:

- Add client config allowing the authority to be overridden
- Add authority to the name resolver interface
- Propagate the authority through to the stream state machine
- Add a percent encoder, as the authority should be percent encoded
- Remove hostname from the client TLS config and use the authority instead. This is generally a usability win as clients generally won't have to set this value themselves.

Result:

Authority is set automatically, and can be overridden if necessary.