### PR TITLE
Add index pages for posix and niots transports

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
@@ -8,8 +8,8 @@ This module provides HTTP/2 transports for client and server built on top SwiftN
 module and uses SwiftNIO's `NIOSSL` module to provide TLS.
 
 The two transport types are:
-- ``HTTP2ClientTransport/Posix``, and
-- ``HTTP2ServerTransport/Posix``.
+- `HTTP2ClientTransport.Posix`, and
+- `HTTP2ServerTransport.Posix`.
 
 ### Availability
 

--- a/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
@@ -32,18 +32,21 @@ Bootstrapping a client or server is made easier using the `.http2NIOPosix` short
 try await withGRPCClient(
   transport: try .http2NIOPosix(
     target: .dns(host: "localhost", port: 31415),
-    config: .defaults(transportSecurity: .tls(.defaults))
+    transportSecurity: .tls
   )
 ) { client in
   // ...
 }
 
-// Create a server listening on "127.0.0.1" on any available port
-// using default plaintext security configuration.
+// Create a plaintext server listening on "127.0.0.1" on any available port
+// modifying the default configuration to set max concurrent streams to 256.
 try await withGRPCServer(
   transport: .http2NIOPosix(
     address: .ipv4(host: "127.0.0.1", port: 0),
-    config: .defaults(transportSecurity: .plaintext)
+    transportSecurity: .plaintext,
+    config: .defaults { config in
+      config.http2.maxConcurrentStreams = 256
+    }
   ),
   services: [...]
 ) { server in

--- a/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Documentation.docc/Documentation.md
@@ -1,0 +1,52 @@
+# ``GRPCNIOTransportHTTP2Posix``
+
+HTTP/2 client and server transports built on top of SwiftNIO's `NIOPosix` module.
+
+## Overview
+
+This module provides HTTP/2 transports for client and server built on top SwiftNIO's `NIOPosix`
+module and uses SwiftNIO's `NIOSSL` module to provide TLS.
+
+The two transport types are:
+- ``HTTP2ClientTransport/Posix``, and
+- ``HTTP2ServerTransport/Posix``.
+
+### Availability
+
+These transports are available on the following platforms:
+
+- Linux (Ubuntu, CentOS, Amazon Linux, Red Hat Universal Base Image)
+- macOS 15.0+
+- iOS 18.0+
+- tvOS 18.0+
+- watchOS 11.0+
+
+
+### Getting started
+
+Bootstrapping a client or server is made easier using the `.http2NIOPosix` shorthand:
+
+```swift
+// Create a server resolving "localhost:31415" using the default transport
+// configuration and default TLS security configuration.
+try await withGRPCClient(
+  transport: try .http2NIOPosix(
+    target: .dns(host: "localhost", port: 31415),
+    config: .defaults(transportSecurity: .tls(.defaults))
+  )
+) { client in
+  // ...
+}
+
+// Create a server listening on "127.0.0.1" on any available port
+// using default plaintext security configuration.
+try await withGRPCServer(
+  transport: .http2NIOPosix(
+    address: .ipv4(host: "127.0.0.1", port: 0),
+    config: .defaults(transportSecurity: .plaintext)
+  ),
+  services: [...]
+) { server in
+  // ...
+}
+```

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
@@ -1,0 +1,51 @@
+# ``GRPCNIOTransportHTTP2TransportServices``
+
+HTTP/2 client and server transports built on top of SwiftNIO's `NIOTransportServices` module.
+
+## Overview
+
+This module provides HTTP/2 transports for client and server built on top SwiftNIO's
+`NIOTransportServices` module which provide TLS via Apple's Network framework.
+
+The two transport types are:
+- ``HTTP2ClientTransport/TransportServices``, and
+- ``HTTP2ServerTransport/TransportServices``.
+
+### Availability
+
+These transports are available on the following platforms:
+
+- macOS 15.0+
+- iOS 18.0+
+- tvOS 18.0+
+- watchOS 11.0+
+
+
+### Getting started
+
+Bootstrapping a client or server is made easier using the `.http2NIOTS` shorthand:
+
+```swift
+// Create a server resolving "localhost:31415" using the default transport
+// configuration and default TLS security configuration.
+try await withGRPCClient(
+  transport: try .http2NIOTS(
+    target: .dns(host: "localhost", port: 31415),
+    config: .defaults(transportSecurity: .tls(.defaults))
+  )
+) { client in
+  // ...
+}
+
+// Create a server listening on "127.0.0.1" on any available port
+// using default plaintext security configuration.
+try await withGRPCServer(
+  transport: .http2NIOTS(
+    address: .ipv4(host: "127.0.0.1", port: 0),
+    config: .defaults(transportSecurity: .plaintext)
+  ),
+  services: [...]
+) { server in
+  // ...
+}
+```

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
@@ -31,7 +31,7 @@ Bootstrapping a client or server is made easier using the `.http2NIOTS` shorthan
 try await withGRPCClient(
   transport: try .http2NIOTS(
     target: .dns(host: "localhost", port: 31415),
-    config: .defaults(transportSecurity: .tls(.defaults))
+    transportSecurity: .tls
   )
 ) { client in
   // ...
@@ -42,7 +42,10 @@ try await withGRPCClient(
 try await withGRPCServer(
   transport: .http2NIOTS(
     address: .ipv4(host: "127.0.0.1", port: 0),
-    config: .defaults(transportSecurity: .plaintext)
+    transportSecurity: .plaintext,
+    config: .defaults { config in
+      config.http2.maxConcurrentStreams = 256
+    }
   ),
   services: [...]
 ) { server in

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Documentation.docc/Documentation.md
@@ -8,8 +8,8 @@ This module provides HTTP/2 transports for client and server built on top SwiftN
 `NIOTransportServices` module which provide TLS via Apple's Network framework.
 
 The two transport types are:
-- ``HTTP2ClientTransport/TransportServices``, and
-- ``HTTP2ServerTransport/TransportServices``.
+- `HTTP2ClientTransport.TransportServices`, and
+- `HTTP2ServerTransport.TransportServices`.
 
 ### Availability
 


### PR DESCRIPTION
Motivation:

The umbrella transport module points to the docs for the POSIX and NIOTS transport which are both empty.

Modifications:

- Add index pages for the two transports
- Fix missing docs

Result:

Better docs