### PR TITLE
Add remote peer info

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -247,6 +247,12 @@ extension ServerBootstrap {
         to: VsockAddress(virtualSocket),
         childChannelInitializer: childChannelInitializer
       )
+    } else if let uds = address.unixDomainSocket {
+      return try await self.bind(
+        unixDomainSocketPath: uds.path,
+        cleanupExistingSocketFile: true,
+        childChannelInitializer: childChannelInitializer
+      )
     } else {
       return try await self.bind(
         to: NIOCore.SocketAddress(address),

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -105,4 +105,20 @@ internal struct ControlClient {
       handler: body
     )
   }
+
+  internal func peerInfo<R>(
+    options: GRPCCore.CallOptions = .defaults,
+    _ body: @Sendable @escaping (
+      _ response: GRPCCore.ClientResponse<String>
+    ) async throws -> R = { try $0.message }
+  ) async throws -> R where R: Sendable {
+    try await self.client.unary(
+      request: ClientRequest(message: ""),
+      descriptor: MethodDescriptor(fullyQualifiedService: "Control", method: "PeerInfo"),
+      serializer: JSONSerializer(),
+      deserializer: JSONDeserializer(),
+      options: options,
+      handler: body
+    )
+  }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -62,6 +62,17 @@ struct ControlService: RegistrableRPCService {
         )
       }
     )
+    router.registerHandler(
+      forMethod: MethodDescriptor(fullyQualifiedService: "Control", method: "PeerInfo"),
+      deserializer: JSONDeserializer<String>(),
+      serializer: JSONSerializer<String>()
+    ) { request, context in
+      return StreamingServerResponse { response in
+        let info = try await self.peerInfo(context: context)
+        try await response.write(info)
+        return [:]
+      }
+    }
   }
 }
 
@@ -88,6 +99,10 @@ extension ControlService {
         }
       }
     }
+  }
+
+  private func peerInfo(context: ServerContext) async throws -> String {
+    return context.peer
   }
 
   private func handle(


### PR DESCRIPTION
Motivation:

The core package added remote peer info to the server context. We should provide that info from connected channels.

Modification:

- Set the remote peer info
- Add tests

Result:

More insight into remote peer