### PR TITLE
Separate out the security config from the rest of the transport config

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -41,7 +41,7 @@ extension HTTP2ServerTransport {
   /// try await withThrowingDiscardingTaskGroup { group in
   ///   let transport = HTTP2ServerTransport.Posix(
   ///     address: .ipv4(host: "127.0.0.1", port: 0),
-  ///     config: .defaults(transportSecurity: .plaintext)
+  ///     transportSecurity: .plaintext
   ///   )
   ///   let server = GRPCServer(transport: transport, services: someServices)
   ///   group.addTask {
@@ -54,6 +54,7 @@ extension HTTP2ServerTransport {
   public struct Posix: ServerTransport, ListeningServerTransport {
     private struct ListenerFactory: HTTP2ListenerFactory {
       let config: Config
+      let transportSecurity: TransportSecurity
 
       func makeListeningChannel(
         eventLoopGroup: any EventLoopGroup,
@@ -62,7 +63,7 @@ extension HTTP2ServerTransport {
       ) async throws -> NIOAsyncChannel<AcceptedChannel, Never> {
         let sslContext: NIOSSLContext?
 
-        switch self.config.transportSecurity.wrapped {
+        switch self.transportSecurity.wrapped {
         case .plaintext:
           sslContext = nil
         case .tls(let tlsConfig):
@@ -97,7 +98,7 @@ extension HTTP2ServerTransport {
 
               let requireALPN: Bool
               let scheme: Scheme
-              switch self.config.transportSecurity.wrapped {
+              switch self.transportSecurity.wrapped {
               case .plaintext:
                 requireALPN = false
                 scheme = .http
@@ -141,14 +142,16 @@ extension HTTP2ServerTransport {
     ///
     /// - Parameters:
     ///   - address: The address to which the server should be bound.
+    ///   - transportSecurity: The configuration for securing network traffic.
     ///   - config: The transport configuration.
     ///   - eventLoopGroup: The ELG from which to get ELs to run this transport.
     public init(
       address: GRPCNIOTransportCore.SocketAddress,
-      config: Config,
+      transportSecurity: TransportSecurity,
+      config: Config = .defaults,
       eventLoopGroup: MultiThreadedEventLoopGroup = .singletonMultiThreadedEventLoopGroup
     ) {
-      let factory = ListenerFactory(config: config)
+      let factory = ListenerFactory(config: config, transportSecurity: transportSecurity)
       let helper = ServerQuiescingHelper(group: eventLoopGroup)
       self.underlyingTransport = CommonHTTP2ServerTransport(
         address: address,
@@ -188,9 +191,6 @@ extension HTTP2ServerTransport.Posix {
     /// RPC configuration.
     public var rpc: HTTP2ServerTransport.Config.RPC
 
-    /// The transport's security.
-    public var transportSecurity: TransportSecurity
-
     /// Construct a new `Config`.
     ///
     /// - Parameters:
@@ -198,38 +198,37 @@ extension HTTP2ServerTransport.Posix {
     ///   - rpc: RPC configuration.
     ///   - connection: Connection configuration.
     ///   - compression: Compression configuration.
-    ///   - transportSecurity: The transport's security configuration.
     ///
-    /// - SeeAlso: ``defaults(transportSecurity:configure:)``
+    /// - SeeAlso: ``defaults(configure:)`` and ``defaults``.
     public init(
       http2: HTTP2ServerTransport.Config.HTTP2,
       rpc: HTTP2ServerTransport.Config.RPC,
       connection: HTTP2ServerTransport.Config.Connection,
-      compression: HTTP2ServerTransport.Config.Compression,
-      transportSecurity: TransportSecurity
+      compression: HTTP2ServerTransport.Config.Compression
     ) {
       self.compression = compression
       self.connection = connection
       self.http2 = http2
       self.rpc = rpc
-      self.transportSecurity = transportSecurity
+    }
+
+    /// Default configuration.
+    public static var defaults: Self {
+      Self.defaults()
     }
 
     /// Default values for the different configurations.
     ///
     /// - Parameters:
-    ///   - transportSecurity: The security settings applied to the transport.
     ///   - configure: A closure which allows you to modify the defaults before returning them.
     public static func defaults(
-      transportSecurity: TransportSecurity,
       configure: (_ config: inout Self) -> Void = { _ in }
     ) -> Self {
       var config = Self(
         http2: .defaults,
         rpc: .defaults,
         connection: .defaults,
-        compression: .defaults,
-        transportSecurity: transportSecurity
+        compression: .defaults
       )
       configure(&config)
       return config
@@ -267,17 +266,20 @@ extension ServerTransport where Self == HTTP2ServerTransport.Posix {
   ///
   /// - Parameters:
   ///   - address: The address to which the server should be bound.
+  ///   - transportSecurity: The configuration for securing network traffic.
   ///   - config: The transport configuration.
   ///   - eventLoopGroup: The underlying NIO `EventLoopGroup` to the server on. This must
   ///       be a `MultiThreadedEventLoopGroup` or an `EventLoop` from
   ///       a `MultiThreadedEventLoopGroup`.
   public static func http2NIOPosix(
     address: GRPCNIOTransportCore.SocketAddress,
-    config: HTTP2ServerTransport.Posix.Config,
+    transportSecurity: HTTP2ServerTransport.Posix.TransportSecurity,
+    config: HTTP2ServerTransport.Posix.Config = .defaults,
     eventLoopGroup: MultiThreadedEventLoopGroup = .singletonMultiThreadedEventLoopGroup
   ) -> Self {
     return HTTP2ServerTransport.Posix(
       address: address,
+      transportSecurity: transportSecurity,
       config: config,
       eventLoopGroup: eventLoopGroup
     )

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
@@ -126,7 +126,7 @@ extension CertificateVerification {
 }
 
 extension TLSConfiguration {
-  package init(_ tlsConfig: HTTP2ServerTransport.Posix.Config.TLS) throws {
+  package init(_ tlsConfig: HTTP2ServerTransport.Posix.TransportSecurity.TLS) throws {
     let certificateChain = try tlsConfig.certificateChain.sslCertificateSources()
     let privateKey = try NIOSSLPrivateKey(privateKey: tlsConfig.privateKey)
 
@@ -142,7 +142,7 @@ extension TLSConfiguration {
     self.applicationProtocols = ["grpc-exp", "h2"]
   }
 
-  package init(_ tlsConfig: HTTP2ClientTransport.Posix.Config.TLS) throws {
+  package init(_ tlsConfig: HTTP2ClientTransport.Posix.TransportSecurity.TLS) throws {
     self = TLSConfiguration.makeClientConfiguration()
     self.certificateChain = try tlsConfig.certificateChain.sslCertificateSources()
 

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -47,7 +47,7 @@ extension HTTP2ClientTransport {
   /// try await withThrowingDiscardingTaskGroup { group in
   ///   let transport = try HTTP2ClientTransport.TransportServices(
   ///     target: .ipv4(host: "example.com"),
-  ///     config: .defaults(transportSecurity: .plaintext)
+  ///     transportSecurity: .plaintext
   ///   )
   ///   let client = GRPCClient(transport: transport)
   ///   group.addTask {
@@ -68,6 +68,7 @@ extension HTTP2ClientTransport {
     ///
     /// - Parameters:
     ///   - target: A target to resolve.
+    ///   - transportSecurity: The configuration for securing network traffic.
     ///   - config: Configuration for the transport.
     ///   - resolverRegistry: A registry of resolver factories.
     ///   - serviceConfig: Service config controlling how the transport should establish and
@@ -78,7 +79,8 @@ extension HTTP2ClientTransport {
     /// - Throws: When no suitable resolver could be found for the `target`.
     public init(
       target: any ResolvableTarget,
-      config: Config,
+      transportSecurity: TransportSecurity,
+      config: Config = .defaults,
       resolverRegistry: NameResolverRegistry = .defaults,
       serviceConfig: ServiceConfig = ServiceConfig(),
       eventLoopGroup: any EventLoopGroup = .singletonNIOTSEventLoopGroup
@@ -95,7 +97,11 @@ extension HTTP2ClientTransport {
 
       self.channel = GRPCChannel(
         resolver: resolver,
-        connector: Connector(eventLoopGroup: eventLoopGroup, config: config),
+        connector: Connector(
+          eventLoopGroup: eventLoopGroup,
+          config: config,
+          transportSecurity: transportSecurity
+        ),
         config: GRPCChannel.Config(transportServices: config),
         defaultServiceConfig: serviceConfig
       )
@@ -126,14 +132,17 @@ extension HTTP2ClientTransport {
 extension HTTP2ClientTransport.TransportServices {
   struct Connector: HTTP2Connector {
     private let config: HTTP2ClientTransport.TransportServices.Config
+    private let transportSecurity: HTTP2ClientTransport.TransportServices.TransportSecurity
     private let eventLoopGroup: any EventLoopGroup
 
     init(
       eventLoopGroup: any EventLoopGroup,
-      config: HTTP2ClientTransport.TransportServices.Config
+      config: HTTP2ClientTransport.TransportServices.Config,
+      transportSecurity: HTTP2ClientTransport.TransportServices.TransportSecurity
     ) {
       self.eventLoopGroup = eventLoopGroup
       self.config = config
+      self.transportSecurity = transportSecurity
     }
 
     func establishConnection(
@@ -142,7 +151,7 @@ extension HTTP2ClientTransport.TransportServices {
     ) async throws -> HTTP2Connection {
       let bootstrap: NIOTSConnectionBootstrap
       let isPlainText: Bool
-      switch self.config.transportSecurity.wrapped {
+      switch self.transportSecurity.wrapped {
       case .plaintext:
         isPlainText = true
         bootstrap = NIOTSConnectionBootstrap(group: self.eventLoopGroup)
@@ -197,9 +206,6 @@ extension HTTP2ClientTransport.TransportServices {
     /// Compression configuration.
     public var compression: HTTP2ClientTransport.Config.Compression
 
-    /// The transport's security.
-    public var transportSecurity: TransportSecurity
-
     /// Creates a new connection configuration.
     ///
     /// - Parameters:
@@ -207,38 +213,37 @@ extension HTTP2ClientTransport.TransportServices {
     ///   - backoff: Backoff configuration.
     ///   - connection: Connection configuration.
     ///   - compression: Compression configuration.
-    ///   - transportSecurity: The transport's security configuration.
     ///
-    /// - SeeAlso: ``defaults(transportSecurity:configure:)``
+    /// - SeeAlso: ``defaults(configure:)`` and ``defaults``.
     public init(
       http2: HTTP2ClientTransport.Config.HTTP2,
       backoff: HTTP2ClientTransport.Config.Backoff,
       connection: HTTP2ClientTransport.Config.Connection,
-      compression: HTTP2ClientTransport.Config.Compression,
-      transportSecurity: TransportSecurity
+      compression: HTTP2ClientTransport.Config.Compression
     ) {
       self.http2 = http2
       self.connection = connection
       self.backoff = backoff
       self.compression = compression
-      self.transportSecurity = transportSecurity
+    }
+
+    /// Default configuration.
+    public static var defaults: Self {
+      Self.defaults()
     }
 
     /// Default values.
     ///
     /// - Parameters:
-    ///   - transportSecurity: The security settings applied to the transport.
     ///   - configure: A closure which allows you to modify the defaults before returning them.
     public static func defaults(
-      transportSecurity: TransportSecurity,
       configure: (_ config: inout Self) -> Void = { _ in }
     ) -> Self {
       var config = Self(
         http2: .defaults,
         backoff: .defaults,
         connection: .defaults,
-        compression: .defaults,
-        transportSecurity: transportSecurity
+        compression: .defaults
       )
       configure(&config)
       return config
@@ -284,6 +289,7 @@ extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   ///
   /// - Parameters:
   ///   - target: A target to resolve.
+  ///   - transportSecurity: The security settings applied to the transport.
   ///   - config: Configuration for the transport.
   ///   - resolverRegistry: A registry of resolver factories.
   ///   - serviceConfig: Service config controlling how the transport should establish and
@@ -294,13 +300,15 @@ extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   /// - Throws: When no suitable resolver could be found for the `target`.
   public static func http2NIOTS(
     target: any ResolvableTarget,
-    config: HTTP2ClientTransport.TransportServices.Config,
+    transportSecurity: HTTP2ClientTransport.TransportServices.TransportSecurity,
+    config: HTTP2ClientTransport.TransportServices.Config = .defaults,
     resolverRegistry: NameResolverRegistry = .defaults,
     serviceConfig: ServiceConfig = ServiceConfig(),
     eventLoopGroup: any EventLoopGroup = .singletonNIOTSEventLoopGroup
   ) throws -> Self {
     try HTTP2ClientTransport.TransportServices(
       target: target,
+      transportSecurity: transportSecurity,
       config: config,
       resolverRegistry: resolverRegistry,
       serviceConfig: serviceConfig,
@@ -311,7 +319,7 @@ extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
 
 extension NWProtocolTLS.Options {
   convenience init(
-    _ tlsConfig: HTTP2ClientTransport.TransportServices.Config.TLS,
+    _ tlsConfig: HTTP2ClientTransport.TransportServices.TLS,
     authority: String?
   ) throws {
     self.init()

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
@@ -24,7 +24,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -44,7 +44,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_IPv6() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .ipv6(host: "::1", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -64,7 +64,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_UnixDomainSocket() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .unixDomainSocket(path: "/tmp/posix-uds-test"),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -88,7 +88,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
 
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .vsock(contextID: .any, port: .any),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -107,7 +107,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_InvalidAddress() async {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .unixDomainSocket(path: "/this/should/be/an/invalid/path"),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -136,7 +136,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_StoppedListening() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -167,9 +167,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testServerConfig_Defaults() throws {
-    let grpcConfig = HTTP2ServerTransport.Posix.Config.defaults(
-      transportSecurity: .plaintext
-    )
+    let grpcConfig = HTTP2ServerTransport.Posix.Config.defaults
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ServerTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ServerTransport.Config.Connection.defaults)
@@ -178,9 +176,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testClientConfig_Defaults() throws {
-    let grpcConfig = HTTP2ClientTransport.Posix.Config.defaults(
-      transportSecurity: .plaintext
-    )
+    let grpcConfig = HTTP2ClientTransport.Posix.Config.defaults
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ClientTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ClientTransport.Config.Connection.defaults)
@@ -281,7 +277,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
     """
 
   func testServerTLSConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ServerTransport.Posix.Config.TLS.defaults(
+    let grpcTLSConfig = HTTP2ServerTransport.Posix.TransportSecurity.TLS.defaults(
       certificateChain: [
         .bytes(Array(Self.samplePemCert.utf8), format: .pem)
       ],
@@ -311,7 +307,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testServerTLSConfig_mTLS() throws {
-    let grpcTLSConfig = HTTP2ServerTransport.Posix.Config.TLS.mTLS(
+    let grpcTLSConfig = HTTP2ServerTransport.Posix.TransportSecurity.TLS.mTLS(
       certificateChain: [
         .bytes(Array(Self.samplePemCert.utf8), format: .pem)
       ],
@@ -341,7 +337,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testServerTLSConfig_FullVerifyClient() throws {
-    var grpcTLSConfig = HTTP2ServerTransport.Posix.Config.TLS.defaults(
+    var grpcTLSConfig = HTTP2ServerTransport.Posix.TransportSecurity.TLS.defaults(
       certificateChain: [
         .bytes(Array(Self.samplePemCert.utf8), format: .pem)
       ],
@@ -372,7 +368,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testServerTLSConfig_CustomTrustRoots() throws {
-    var grpcTLSConfig = HTTP2ServerTransport.Posix.Config.TLS.defaults(
+    var grpcTLSConfig = HTTP2ServerTransport.Posix.TransportSecurity.TLS.defaults(
       certificateChain: [
         .bytes(Array(Self.samplePemCert.utf8), format: .pem)
       ],
@@ -406,7 +402,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testClientTLSConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ClientTransport.Posix.Config.TLS.defaults
+    let grpcTLSConfig = HTTP2ClientTransport.Posix.TransportSecurity.TLS.defaults
     let nioSSLTLSConfig = try TLSConfiguration(grpcTLSConfig)
 
     XCTAssertEqual(nioSSLTLSConfig.certificateChain, [])
@@ -418,7 +414,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testClientTLSConfig_CustomCertificateChainAndPrivateKey() throws {
-    var grpcTLSConfig = HTTP2ClientTransport.Posix.Config.TLS.defaults
+    var grpcTLSConfig = HTTP2ClientTransport.Posix.TransportSecurity.TLS.defaults
     grpcTLSConfig.certificateChain = [
       .bytes(Array(Self.samplePemCert.utf8), format: .pem)
     ]
@@ -447,7 +443,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testClientTLSConfig_CustomTrustRoots() throws {
-    var grpcTLSConfig = HTTP2ClientTransport.Posix.Config.TLS.defaults
+    var grpcTLSConfig = HTTP2ClientTransport.Posix.TransportSecurity.TLS.defaults
     grpcTLSConfig.trustRoots = .certificates([.bytes(Array(Self.samplePemCert.utf8), format: .pem)])
     let nioSSLTLSConfig = try TLSConfiguration(grpcTLSConfig)
 
@@ -463,7 +459,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testClientTLSConfig_CustomCertificateVerification() throws {
-    var grpcTLSConfig = HTTP2ClientTransport.Posix.Config.TLS.defaults
+    var grpcTLSConfig = HTTP2ClientTransport.Posix.TransportSecurity.TLS.defaults
     grpcTLSConfig.serverCertificateVerification = .noHostnameVerification
     let nioSSLTLSConfig = try TLSConfiguration(grpcTLSConfig)
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -73,7 +73,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -93,7 +93,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv6() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv6(host: "::1", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -113,7 +113,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_UnixDomainSocket() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/tmp/niots-uds-test"),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
     defer {
       // NIOTS does not unlink the UDS on close.
@@ -139,7 +139,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_InvalidAddress() async {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/this/should/be/an/invalid/path"),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -168,7 +168,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_StoppedListening() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults(transportSecurity: .plaintext)
+      transportSecurity: .plaintext
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -199,12 +199,10 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   }
 
   func testServerConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ServerTransport.TransportServices.Config.TLS.defaults(
+    let grpcTLSConfig = HTTP2ServerTransport.TransportServices.TLS.defaults(
       identityProvider: Self.loadIdentity
     )
-    let grpcConfig = HTTP2ServerTransport.TransportServices.Config.defaults(
-      transportSecurity: .tls(grpcTLSConfig)
-    )
+    let grpcConfig = HTTP2ServerTransport.TransportServices.Config.defaults
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ServerTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ServerTransport.Config.Connection.defaults)
@@ -218,10 +216,8 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   }
 
   func testClientConfig_Defaults() throws {
-    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.Config.TLS.defaults()
-    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults(
-      transportSecurity: .tls(grpcTLSConfig)
-    )
+    let grpcTLSConfig = HTTP2ClientTransport.TransportServices.TLS.defaults
+    let grpcConfig = HTTP2ClientTransport.TransportServices.Config.defaults
 
     XCTAssertEqual(grpcConfig.compression, HTTP2ClientTransport.Config.Compression.defaults)
     XCTAssertEqual(grpcConfig.connection, HTTP2ClientTransport.Config.Connection.defaults)

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -148,7 +148,8 @@ final class HTTP2TransportTests: XCTestCase {
       let server = GRPCServer(
         transport: .http2NIOPosix(
           address: address,
-          config: .defaults(transportSecurity: .plaintext) {
+          transportSecurity: .plaintext,
+          config: .defaults {
             $0.compression.enabledAlgorithms = compression
           }
         ),
@@ -167,7 +168,8 @@ final class HTTP2TransportTests: XCTestCase {
       let server = GRPCServer(
         transport: .http2NIOTS(
           address: address,
-          config: .defaults(transportSecurity: .plaintext) {
+          transportSecurity: .plaintext,
+          config: .defaults {
             $0.compression.enabledAlgorithms = compression
           }
         ),
@@ -200,7 +202,8 @@ final class HTTP2TransportTests: XCTestCase {
       serviceConfig.loadBalancingConfig = [.roundRobin]
       transport = try HTTP2ClientTransport.Posix(
         target: target,
-        config: .defaults(transportSecurity: .plaintext) {
+        transportSecurity: .plaintext,
+        config: .defaults {
           $0.compression.algorithm = compression
           $0.compression.enabledAlgorithms = enabledCompression
         },
@@ -213,7 +216,8 @@ final class HTTP2TransportTests: XCTestCase {
       serviceConfig.loadBalancingConfig = [.roundRobin]
       transport = try HTTP2ClientTransport.TransportServices(
         target: target,
-        config: .defaults(transportSecurity: .plaintext) {
+        transportSecurity: .plaintext,
+        config: .defaults {
           $0.compression.algorithm = compression
           $0.compression.enabledAlgorithms = enabledCompression
         },
@@ -1508,7 +1512,7 @@ final class HTTP2TransportTests: XCTestCase {
     try await withGRPCServer(
       transport: .http2NIOPosix(
         address: serverAddress,
-        config: .defaults(transportSecurity: .plaintext)
+        transportSecurity: .plaintext
       ),
       services: [ControlService()]
     ) { server in
@@ -1521,7 +1525,8 @@ final class HTTP2TransportTests: XCTestCase {
       try await withGRPCClient(
         transport: .http2NIOPosix(
           target: target,
-          config: .defaults(transportSecurity: .plaintext) {
+          transportSecurity: .plaintext,
+          config: .defaults {
             $0.http2.authority = override
           }
         )


### PR DESCRIPTION
Motivation:

Users must explicitly state whether they want TLS or plaintext. This config for this is currently nested within the rest of the config for the transport. In many cases this results in users writing `.defaults(transportSecurity: .tls(.defaults(...)))` where `.defaults(...)` often includes various TLS config. This is verbose and a little bit finicky to use.

Modifications:

- Seprate out the transport security from the rest of the config and have the client and server transport take a config _and_ a transport security config.
- This allows for APIs which compose better while also allowing for the transport config to just use a set of defaults.

Result:

Easier to use API.