### PR TITLE
Modify which symbols are documented

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,5 +3,3 @@ builder:
   configs:
     - documentation_targets: [GRPCNIOTransportHTTP2, GRPCNIOTransportHTTP2Posix, GRPCNIOTransportHTTP2TransportServices]
       swift_version: 6.0
-      # Don't include @_exported types from GRPCCore
-      custom_documentation_parameters: [--exclude-extended-types]


### PR DESCRIPTION
Motivation:

The .spi.yml was configured to exclude extended type to avoid documenting the types from the re-exported `GRPCCore` module and the core http2 module.

Modifications:

- Remove the config

Result:

Better docs