### PR TITLE
Workaround #43 in tests

### DIFF
--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1400,6 +1400,8 @@ final class HTTP2TransportTests: XCTestCase {
       let request = ClientRequest(message: input)
       try await control.serverStream(request: request) { response in
         XCTAssertEqual(Array(response.metadata["echo-scheme"]), ["http"])
+        // Workaround https://github.com/grpc/grpc-swift-nio-transport/issues/43
+        for try await _ in response.messages {}
       }
     }
   }
@@ -1430,6 +1432,8 @@ final class HTTP2TransportTests: XCTestCase {
       }
       try await control.bidiStream(request: request) { response in
         XCTAssertEqual(Array(response.metadata["echo-scheme"]), ["http"])
+        // Workaround https://github.com/grpc/grpc-swift-nio-transport/issues/43
+        for try await _ in response.messages {}
       }
     }
   }


### PR DESCRIPTION
Motivation:

A couple of tests fail sometimes, the root cause of which is #43.

Modifications:

- Wait for all messages to be received before closing

Result:

Tests are more stable