### PR TITLE
Reset go away state

### DIFF
--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
@@ -295,6 +295,7 @@ final class PickFirstLoadBalancerTests: XCTestCase {
       case .connectivityStateChanged(.ready):
         switch idleCount.value {
         case 1:
+          XCTAssertNotNil(context.loadBalancer.pickSubchannel())
           // Must be connected to server 1, send a GOAWAY frame.
           let channel = context.servers[0].server.clients.first!
           let goAway = HTTP2Frame(
@@ -307,6 +308,7 @@ final class PickFirstLoadBalancerTests: XCTestCase {
           // Must only be connected to server 2 now.
           XCTAssertEqual(context.servers[0].server.clients.count, 0)
           XCTAssertEqual(context.servers[1].server.clients.count, 1)
+          XCTAssertNotNil(context.loadBalancer.pickSubchannel())
           context.loadBalancer.close()
 
         default:


### PR DESCRIPTION
Motivation:

The pick first load balancer keeps track of whether the current subchannel is going away. This is done so that if there isn't yet a subchannel to roll over too it won't be offered up when the GRPCChannel asks for a subchannel. However, this state wasn't reset in enough places within the state machine.

Modifications:

- Reset the is-going-away state when updating the current subchannel and when the current subchannel becomes idle

Result:

Resolves #40