### PR TITLE
Increase minimum `swift-nio-http2` version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.34.1"
+    from: "1.35.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",


### PR DESCRIPTION
The latest minor release of `swift-nio-http2` (1.35.0) fixes a bug that would sometimes cause a gRPC server to wedge when TLS setup failed.

This PR increases the minimum version of `swift-nio-http2` required to make sure this bug isn't present.