### PR TITLE
Fix warnings from new NIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.75.0"
+    from: "2.78.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",

--- a/Sources/GRPCNIOTransportCore/Internal/Base64.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Base64.swift
@@ -71,13 +71,13 @@
  */
 
 // swift-format-ignore: DontRepeatTypeInStaticProperties
-enum Base64 {
-  struct DecodingOptions: OptionSet {
-    internal let rawValue: UInt
-    internal init(rawValue: UInt) { self.rawValue = rawValue }
+package enum Base64 {
+  package struct DecodingOptions: OptionSet {
+    package let rawValue: UInt
+    package init(rawValue: UInt) { self.rawValue = rawValue }
 
-    internal static let base64UrlAlphabet = DecodingOptions(rawValue: UInt(1 << 0))
-    internal static let omitPaddingCharacter = DecodingOptions(rawValue: UInt(1 << 1))
+    package static let base64UrlAlphabet = DecodingOptions(rawValue: UInt(1 << 0))
+    package static let omitPaddingCharacter = DecodingOptions(rawValue: UInt(1 << 1))
   }
 
   enum DecodingError: Error, Equatable {
@@ -87,7 +87,9 @@ enum Base64 {
     case unexpectedEnd
   }
 
-  static func encode<Buffer: Collection>(bytes: Buffer) -> String where Buffer.Element == UInt8 {
+  package static func encode<Buffer: Collection>(
+    bytes: Buffer
+  ) -> String where Buffer.Element == UInt8 {
     guard !bytes.isEmpty else {
       return ""
     }
@@ -122,7 +124,7 @@ enum Base64 {
     }
   }
 
-  static func decode(
+  package static func decode(
     string encoded: String,
     options: DecodingOptions = []
   ) throws -> [UInt8] {

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -438,7 +438,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
           GRPCHTTP2Keys.encoding.rawValue: "deflate",
           "custom": "123",
-          "custom-bin": String(base64Encoding: [42, 43, 44]),
+          "custom-bin": Base64.encode(bytes: [42, 43, 44]),
         ],
         endStream: false
       )
@@ -466,7 +466,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
           GRPCHTTP2Keys.encoding.rawValue: "deflate",
           "custom": "123",
-          "custom-bin": String(base64Encoding: [42, 43, 44]),
+          "custom-bin": Base64.encode(bytes: [42, 43, 44]),
         ],
         endStream: false
       )
@@ -493,7 +493,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
           GRPCHTTP2Keys.encoding.rawValue: "deflate",
           "custom": "123",
-          "custom-bin": String(base64Encoding: [42, 43, 44]),
+          "custom-bin": Base64.encode(bytes: [42, 43, 44]),
         ],
         endStream: false
       )

--- a/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
@@ -167,7 +167,7 @@ struct ServerConnectionManagementHandlerTests {
     // Write a frame into the channel _without_ calling channel read complete. This will cancel
     // the keep alive timer.
     let settings = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-    connection.channel.pipeline.fireChannelRead(NIOAny(settings))
+    connection.channel.pipeline.fireChannelRead(settings)
 
     // Run out the keep alive timer, it shouldn't fire.
     connection.advanceTime(by: .minutes(5))

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -1071,7 +1071,7 @@ struct ServerStreamHandlerTests {
       #expect(!handle.isCancelled)
 
       let rstStream: HTTP2Frame.FramePayload = .rstStream(.cancel)
-      channel.pipeline.fireChannelRead(NIOAny(rstStream))
+      channel.pipeline.fireChannelRead(rstStream)
 
       #expect(handle.isCancelled)
     }
@@ -1091,7 +1091,7 @@ struct ServerStreamHandlerTests {
 
     // FrameStats aren't affected by pings received
     channel.pipeline.fireChannelRead(
-      NIOAny(HTTP2Frame.FramePayload.ping(.init(withInteger: 42), ack: false))
+      HTTP2Frame.FramePayload.ping(.init(withInteger: 42), ack: false)
     )
     #expect(!handlers.connectionHandler.frameStats.didWriteHeadersOrData)
 


### PR DESCRIPTION
Motivation:

The latest NIO release deprecated some APIs.

Modifications:

- Use non-deprecated APIs

Result:

No warnings