### PR TITLE
Adopt `ClientContext` changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    exact: "2.0.0-beta.2"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -202,10 +202,10 @@ package final class Connection: Sendable {
     descriptor: MethodDescriptor,
     options: CallOptions
   ) async throws -> Stream {
-    let (multiplexer, scheme) = try self.state.withLock { state in
+    let (multiplexer, scheme, remotePeer, localPeer) = try self.state.withLock { state in
       switch state {
       case .connected(let connected):
-        return (connected.multiplexer, connected.scheme)
+        return (connected.multiplexer, connected.scheme, connected.remotePeer, connected.localPeer)
       case .notConnected, .closing, .closed:
         throw RPCError(code: .unavailable, message: "subchannel isn't ready")
       }
@@ -246,7 +246,13 @@ package final class Connection: Sendable {
         }
       }
 
-      return Stream(wrapping: stream, descriptor: descriptor)
+      let context = ClientContext(
+        descriptor: descriptor,
+        remotePeer: remotePeer,
+        localPeer: localPeer
+      )
+
+      return Stream(wrapping: stream, context: context)
     } catch {
       throw RPCError(code: .unavailable, message: "subchannel is unavailable", cause: error)
     }
@@ -417,24 +423,16 @@ extension Connection {
       }
     }
 
-    let descriptor: MethodDescriptor
+    let context: ClientContext
 
     private let http2Stream: NIOAsyncChannel<RPCResponsePart, RPCRequestPart>
 
-    var peerInfo: String {
-      self.http2Stream.channel.getRemoteAddressInfo()
-    }
-
-    var localInfo: String {
-      self.http2Stream.channel.getLocalAddressInfo()
-    }
-
     init(
       wrapping stream: NIOAsyncChannel<RPCResponsePart, RPCRequestPart>,
-      descriptor: MethodDescriptor
+      context: ClientContext
     ) {
       self.http2Stream = stream
-      self.descriptor = descriptor
+      self.context = context
     }
 
     package func execute<T>(
@@ -465,6 +463,10 @@ extension Connection {
     struct Connected: Sendable {
       /// The connection channel.
       var channel: NIOAsyncChannel<ClientConnectionEvent, Void>
+      /// The connection's remote peer information.
+      var remotePeer: String
+      /// The connection's local peer information.
+      var localPeer: String
       /// Multiplexer for creating HTTP/2 streams.
       var multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
       /// Whether the connection is plaintext, `false` implies TLS is being used.
@@ -472,6 +474,8 @@ extension Connection {
 
       init(_ connection: HTTP2Connection) {
         self.channel = connection.channel
+        self.remotePeer = connection.channel.remoteAddressInfo
+        self.localPeer = connection.channel.localAddressInfo
         self.multiplexer = connection.multiplexer
         self.scheme = connection.isPlaintext ? .http : .https
       }

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -421,6 +421,14 @@ extension Connection {
 
     private let http2Stream: NIOAsyncChannel<RPCResponsePart, RPCRequestPart>
 
+    var peerInfo: String {
+      self.http2Stream.channel.getRemoteAddressInfo()
+    }
+
+    var localInfo: String {
+      self.http2Stream.channel.getLocalAddressInfo()
+    }
+
     init(
       wrapping stream: NIOAsyncChannel<RPCResponsePart, RPCRequestPart>,
       descriptor: MethodDescriptor

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -220,7 +220,7 @@ package final class GRPCChannel: ClientTransport {
           )
           let context = ClientContext(
             descriptor: descriptor,
-            remotePeer: stream.peerInfo ,
+            remotePeer: stream.peerInfo,
             localPeer: stream.localInfo,
             serverHostname: self.authority ?? "<unknown>",
             networkTransportMethod: "tcp"

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -202,10 +202,7 @@ package final class GRPCChannel: ClientTransport {
   package func withStream<T: Sendable>(
     descriptor: MethodDescriptor,
     options: CallOptions,
-    _ closure: (
-      _ stream: RPCStream<ClientTransport.Inbound, ClientTransport.Outbound>,
-      _ context: ClientContext
-    ) async throws -> T
+    _ closure: (_ stream: RPCStream<Inbound, Outbound>, _ context: ClientContext) async throws -> T
   ) async throws -> T {
     // Merge options from the call with those from the service config.
     let methodConfig = self.config(forMethod: descriptor)

--- a/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import NIOCore
+internal import NIOCore
 
-extension Channel {
-  func getRemoteAddressInfo() -> String {
-    guard let remote = self.remoteAddress else {
+extension NIOAsyncChannel {
+  var remoteAddressInfo: String {
+    guard let remote = self.channel.remoteAddress else {
       return "<unknown>"
     }
 
@@ -33,7 +33,7 @@ extension Channel {
 
     case .unixDomainSocket:
       // The pathname will be on the local address.
-      guard let local = self.localAddress else {
+      guard let local = self.channel.localAddress else {
         // UDS but no local address; this shouldn't ever happen but at least note the transport
         // as being UDS.
         return "unix:<unknown>"
@@ -51,8 +51,8 @@ extension Channel {
     }
   }
 
-  func getLocalAddressInfo() -> String {
-    guard let local = self.localAddress else {
+  var localAddressInfo: String {
+    guard let local = self.channel.localAddress else {
       return "<unknown>"
     }
 

--- a/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOCore
+
+extension Channel {
+  func getRemoteAddressInfo() -> String {
+    guard let remote = self.remoteAddress else {
+      return "<unknown>"
+    }
+
+    switch remote {
+    case .v4(let address):
+      // '!' is safe, v4 always has a port.
+      return "ipv4:\(address.host):\(remote.port!)"
+
+    case .v6(let address):
+      // '!' is safe, v6 always has a port.
+      return "ipv6:[\(address.host)]:\(remote.port!)"
+
+    case .unixDomainSocket:
+      // The pathname will be on the local address.
+      guard let local = self.localAddress else {
+        // UDS but no local address; this shouldn't ever happen but at least note the transport
+        // as being UDS.
+        return "unix:<unknown>"
+      }
+
+      switch local {
+      case .unixDomainSocket:
+        // '!' is safe, UDS always has a path.
+        return "unix:\(local.pathname!)"
+
+      case .v4, .v6:
+        // Remote address is UDS but local isn't. This shouldn't ever happen.
+        return "unix:<unknown>"
+      }
+    }
+  }
+
+  func getLocalAddressInfo() -> String {
+    guard let local = self.localAddress else {
+      return "<unknown>"
+    }
+
+    switch local {
+    case .v4(let address):
+      // '!' is safe, v4 always has a port.
+      return "ipv4:\(address.host):\(local.port!)"
+
+    case .v6(let address):
+      // '!' is safe, v6 always has a port.
+      return "ipv6:[\(address.host)]:\(local.port!)"
+
+    case .unixDomainSocket:
+      // '!' is safe, UDS always has a path.
+      return "unix:\(local.pathname!)"
+    }
+  }
+}

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -199,7 +199,7 @@ package final class CommonHTTP2ServerTransport<
       _ context: ServerContext
     ) async -> Void
   ) async throws {
-    let peer = connection.channel.getRemoteAddressInfo()
+    let peer = connection.remoteAddressInfo
     try await connection.executeThenClose { inbound, _ in
       await withDiscardingTaskGroup { group in
         group.addTask {

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
@@ -120,7 +120,7 @@ extension HTTP2ClientTransport {
     public func withStream<T: Sendable>(
       descriptor: MethodDescriptor,
       options: CallOptions,
-      _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+      _ closure: (RPCStream<Inbound, Outbound>, ClientContext) async throws -> T
     ) async throws -> T {
       try await self.channel.withStream(descriptor: descriptor, options: options, closure)
     }

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -118,7 +118,7 @@ extension HTTP2ClientTransport {
     public func withStream<T: Sendable>(
       descriptor: MethodDescriptor,
       options: CallOptions,
-      _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+      _ closure: (RPCStream<Inbound, Outbound>, ClientContext) async throws -> T
     ) async throws -> T {
       try await self.channel.withStream(descriptor: descriptor, options: options, closure)
     }

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
@@ -353,7 +353,7 @@ final class GRPCChannelTests: XCTestCase {
         await channel.connect()
       }
 
-      try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+      try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream, _ in
         try await stream.outbound.write(.metadata([:]))
 
         var iterator = stream.inbound.makeAsyncIterator()
@@ -441,7 +441,7 @@ final class GRPCChannelTests: XCTestCase {
       // be queued though.
       for _ in 1 ... 100 {
         group.addTask {
-          try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+          try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream, _ in
             try await stream.outbound.write(.metadata([:]))
             await stream.outbound.finish()
 
@@ -510,7 +510,7 @@ final class GRPCChannelTests: XCTestCase {
           options.waitForReady = false
 
           await XCTAssertThrowsErrorAsync(ofType: RPCError.self) {
-            try await channel.withStream(descriptor: .echoGet, options: options) { _ in
+            try await channel.withStream(descriptor: .echoGet, options: options) { _, _ in
               XCTFail("Unexpected stream")
             }
           } errorHandler: { error in
@@ -780,7 +780,7 @@ final class GRPCChannelTests: XCTestCase {
 
           // Try to open a new stream.
           await XCTAssertThrowsErrorAsync(ofType: RPCError.self) {
-            try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+            try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream, _ in
               XCTFail("Unexpected new stream")
             }
           } errorHandler: { error in
@@ -823,7 +823,7 @@ final class GRPCChannelTests: XCTestCase {
       }
 
       func doAnRPC() async throws {
-        try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+        try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream, _ in
           try await stream.outbound.write(.metadata([:]))
           await stream.outbound.finish()
 
@@ -873,7 +873,7 @@ extension GRPCChannel {
     let values: Metadata.StringValues? = try await self.withStream(
       descriptor: .echoGet,
       options: .defaults
-    ) { stream in
+    ) { stream, _ in
       try await stream.outbound.write(.metadata([:]))
       await stream.outbound.finish()
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -109,7 +109,7 @@ internal struct ControlClient {
   internal func peerInfo<R>(
     options: GRPCCore.CallOptions = .defaults,
     _ body: @Sendable @escaping (
-      _ response: GRPCCore.ClientResponse<String>
+      _ response: GRPCCore.ClientResponse<ControlService.PeerInfoResponse>
     ) async throws -> R = { try $0.message }
   ) async throws -> R where R: Sendable {
     try await self.client.unary(

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -69,11 +69,11 @@ struct ControlService: RegistrableRPCService {
     ) { request, context in
       return StreamingServerResponse { response in
         let responseString = """
-        \(self.serverRemotePeerInfo(context: context))\n
-        \(self.serverLocalPeerInfo(context: context))\n
-        \(self.clientRemotePeerInfo(request: request))\n
-        \(self.clientLocalPeerInfo(request: request))
-        """
+          \(self.serverRemotePeerInfo(context: context))\n
+          \(self.serverLocalPeerInfo(context: context))\n
+          \(self.clientRemotePeerInfo(request: request))\n
+          \(self.clientLocalPeerInfo(request: request))
+          """
 
         try await response.write(responseString)
 
@@ -294,7 +294,7 @@ struct PeerInfoClientInterceptor: ClientInterceptor {
       StreamingClientRequest<Input>,
       ClientContext
     ) async throws -> StreamingClientResponse<Output>
-  ) async throws -> StreamingClientResponse<Output> where Input : Sendable, Output : Sendable {
+  ) async throws -> StreamingClientResponse<Output> where Input: Sendable, Output: Sendable {
     var request = request
     request.metadata.addString(context.localPeer, forKey: "localPeer")
     request.metadata.addString(context.remotePeer, forKey: "remotePeer")

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -113,21 +113,19 @@ extension ControlService {
   }
 
   private func serverRemotePeerInfo(context: ServerContext) -> String {
-    "Server's remote peer: \(context.peer)"
+    context.peer
   }
 
   private func serverLocalPeerInfo(context: ServerContext) -> String {
-    "Server's local peer: <not yet implemented>"
+    "<not yet implemented>"
   }
 
   private func clientRemotePeerInfo<T>(request: StreamingServerRequest<T>) -> String {
-    let remotePeer = request.metadata[stringValues: "remotePeer"].first(where: { _ in true })!
-    return "Client's remote peer: \(remotePeer)"
+    request.metadata[stringValues: "remotePeer"].first(where: { _ in true })!
   }
 
   private func clientLocalPeerInfo<T>(request: StreamingServerRequest<T>) -> String {
-    let localPeer = request.metadata[stringValues: "localPeer"].first(where: { _ in true })!
-    return "Client's local peer: \(localPeer)"
+    request.metadata[stringValues: "localPeer"].first(where: { _ in true })!
   }
 
   private func handle(

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1640,21 +1640,25 @@ final class HTTP2TransportTests: XCTestCase {
       }
 
       let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(of: /Server's remote peer: ipv4:127.0.0.1:(\d+)/)
+      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+        of: /Server's remote peer: ipv4:127.0.0.1:(\d+)/
+      )
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-//      let serverLocalPeer = addresses[1]
-//      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
-//      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
+      //      let serverLocalPeer = addresses[1]
+      //      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-//      let clientRemotePeer = addresses[2]
-//      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv4:127.0.0.1:(\d+)/)
-//      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
+      //      let clientRemotePeer = addresses[2]
+      //      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv4:127.0.0.1:(\d+)/)
+      //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
       let clientLocalPeer = addresses[3]
-      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(of: /Client's local peer: ipv4:127.0.0.1:(\d+)/)
+      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(
+        of: /Client's local peer: ipv4:127.0.0.1:(\d+)/
+      )
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
     }
   }
@@ -1672,21 +1676,25 @@ final class HTTP2TransportTests: XCTestCase {
       }
 
       let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(of: /Server's remote peer: ipv6:[::1]:(\d+)/)
+      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+        of: /Server's remote peer: ipv6:[::1]:(\d+)/
+      )
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-//      let serverLocalPeer = addresses[1]
-//      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
-//      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
+      //      let serverLocalPeer = addresses[1]
+      //      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-//      let clientRemotePeer = addresses[2]
-//      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv6:[::1]:(\d+)/)
-//      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
+      //      let clientRemotePeer = addresses[2]
+      //      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv6:[::1]:(\d+)/)
+      //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
       let clientLocalPeer = addresses[3]
-      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(of: /Client's local peer: ipv6:[::1]:(\d+)/)
+      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(
+        of: /Client's local peer: ipv6:[::1]:(\d+)/
+      )
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
     }
   }
@@ -1705,15 +1713,21 @@ final class HTTP2TransportTests: XCTestCase {
       }
 
       let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(of: /Server's remote peer: unix:peer-info-uds/)
+      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+        of: /Server's remote peer: unix:peer-info-uds/
+      )
       XCTAssertNotNil(serverRemotePeerMatches)
 
       let serverLocalPeer = addresses[1]
-      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(
+        of: /Server's local peer: <not yet implemented>/
+      )
       XCTAssertNotNil(serverLocalPeerMatches)
 
       let clientRemotePeer = addresses[2]
-      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: unix:peer-info-uds/)
+      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(
+        of: /Client's remote peer: unix:peer-info-uds/
+      )
       XCTAssertNotNil(clientRemotePeerMatches)
 
       let clientLocalPeer = addresses[3]

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1632,31 +1632,21 @@ final class HTTP2TransportTests: XCTestCase {
       serverAddress: .ipv4(host: "127.0.0.1", port: 0)
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
-      let addresses = peerInfo.split(separator: "\n")
 
-      guard addresses.count == 4 else {
-        XCTFail("Unexpected response: should have received 4 different addresses, got \(addresses)")
-        return
-      }
-
-      let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
         of: /Server's remote peer: ipv4:127.0.0.1:(\d+)/
       )
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-      //      let serverLocalPeer = addresses[1]
-      //      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /Server's local peer: <not yet implemented>/)
       //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-      //      let clientRemotePeer = addresses[2]
-      //      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv4:127.0.0.1:(\d+)/)
+      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /Client's remote peer: ipv4:127.0.0.1:(\d+)/)
       //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
-      let clientLocalPeer = addresses[3]
-      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(
+      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
         of: /Client's local peer: ipv4:127.0.0.1:(\d+)/
       )
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
@@ -1668,31 +1658,21 @@ final class HTTP2TransportTests: XCTestCase {
       serverAddress: .ipv6(host: "::1", port: 0)
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
-      let addresses = peerInfo.split(separator: "\n")
 
-      guard addresses.count == 4 else {
-        XCTFail("Unexpected response: should have received 4 different addresses, got \(addresses)")
-        return
-      }
-
-      let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
         of: /Server's remote peer: ipv6:[::1]:(\d+)/
       )
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-      //      let serverLocalPeer = addresses[1]
-      //      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /Server's local peer: <not yet implemented>/)
       //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-      //      let clientRemotePeer = addresses[2]
-      //      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(of: /Client's remote peer: ipv6:[::1]:(\d+)/)
+      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /Client's remote peer: ipv6:[::1]:(\d+)/)
       //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
-      let clientLocalPeer = addresses[3]
-      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(
+      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
         of: /Client's local peer: ipv6:[::1]:(\d+)/
       )
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
@@ -1705,33 +1685,25 @@ final class HTTP2TransportTests: XCTestCase {
       serverAddress: .unixDomainSocket(path: path)
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
-      let addresses = peerInfo.split(separator: "\n")
 
-      guard addresses.count == 4 else {
-        XCTFail("Unexpected response: should have received 4 different addresses, got \(addresses)")
-        return
-      }
-
-      let serverRemotePeer = addresses[0]
-      let serverRemotePeerMatches = serverRemotePeer.wholeMatch(
+      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
         of: /Server's remote peer: unix:peer-info-uds/
       )
       XCTAssertNotNil(serverRemotePeerMatches)
 
-      let serverLocalPeer = addresses[1]
-      let serverLocalPeerMatches = serverLocalPeer.wholeMatch(
+      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(
         of: /Server's local peer: <not yet implemented>/
       )
       XCTAssertNotNil(serverLocalPeerMatches)
 
-      let clientRemotePeer = addresses[2]
-      let clientRemotePeerMatches = clientRemotePeer.wholeMatch(
+      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(
         of: /Client's remote peer: unix:peer-info-uds/
       )
       XCTAssertNotNil(clientRemotePeerMatches)
 
-      let clientLocalPeer = addresses[3]
-      let clientLocalPeerMatches = clientLocalPeer.wholeMatch(of: /Client's local peer: unix:/)
+      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
+        of: /Client's local peer: unix:peer-info-uds/
+      )
       XCTAssertNotNil(clientLocalPeerMatches)
     }
   }

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1633,22 +1633,18 @@ final class HTTP2TransportTests: XCTestCase {
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
 
-      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
-        of: /Server's remote peer: ipv4:127.0.0.1:(\d+)/
-      )
+      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(of: /ipv4:127\.0\.0\.1:(\d+)/)
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /<not yet implemented>/)
       //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /Client's remote peer: ipv4:127.0.0.1:(\d+)/)
+      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /ipv4:127.0.0.1:(\d+)/)
       //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
-      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
-        of: /Client's local peer: ipv4:127.0.0.1:(\d+)/
-      )
+      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(of: /ipv4:127\.0\.0\.1:(\d+)/)
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
     }
   }
@@ -1659,22 +1655,18 @@ final class HTTP2TransportTests: XCTestCase {
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
 
-      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
-        of: /Server's remote peer: ipv6:[::1]:(\d+)/
-      )
+      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(of: /ipv6:\[::1\]:(\d+)/)
       let clientPort = try XCTUnwrap(serverRemotePeerMatches).1
 
       // TODO: Uncomment when server local peer info is implemented
 
-      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /Server's local peer: <not yet implemented>/)
+      //      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(of: /<not yet implemented>/)
       //      let serverPort = XCTUnwrap(serverLocalPeerMatches).1
 
-      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /Client's remote peer: ipv6:[::1]:(\d+)/)
+      //      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(of: /ipv6:\[::1\]:(\d+)/)
       //      XCTAssertEqual(try XCTUnwrap(clientRemotePeerMatches).1, serverPort)
 
-      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
-        of: /Client's local peer: ipv6:[::1]:(\d+)/
-      )
+      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(of: /ipv6:\[::1\]:(\d+)/)
       XCTAssertEqual(try XCTUnwrap(clientLocalPeerMatches).1, clientPort)
     }
   }
@@ -1686,25 +1678,11 @@ final class HTTP2TransportTests: XCTestCase {
     ) { control, _, _ in
       let peerInfo = try await control.peerInfo()
 
-      let serverRemotePeerMatches = peerInfo.server.remote.wholeMatch(
-        of: /Server's remote peer: unix:peer-info-uds/
-      )
-      XCTAssertNotNil(serverRemotePeerMatches)
+      XCTAssertNotNil(peerInfo.server.remote.wholeMatch(of: /unix:peer-info-uds/))
+      XCTAssertNotNil(peerInfo.server.local.wholeMatch(of: /<not yet implemented>/))
 
-      let serverLocalPeerMatches = peerInfo.server.local.wholeMatch(
-        of: /Server's local peer: <not yet implemented>/
-      )
-      XCTAssertNotNil(serverLocalPeerMatches)
-
-      let clientRemotePeerMatches = peerInfo.client.remote.wholeMatch(
-        of: /Client's remote peer: unix:peer-info-uds/
-      )
-      XCTAssertNotNil(clientRemotePeerMatches)
-
-      let clientLocalPeerMatches = peerInfo.client.local.wholeMatch(
-        of: /Client's local peer: unix:peer-info-uds/
-      )
-      XCTAssertNotNil(clientLocalPeerMatches)
+      XCTAssertNotNil(peerInfo.client.remote.wholeMatch(of: /unix:peer-info-uds/))
+      XCTAssertNotNil(peerInfo.client.local.wholeMatch(of: /unix:peer-info-uds/))
     }
   }
 }

--- a/dev/license-check.sh
+++ b/dev/license-check.sh
@@ -88,7 +88,7 @@ check_copyright_headers() {
 
     actual_sha=$(head -n "$((drop_first + expected_lines))" "$filename" \
       | tail -n "$expected_lines" \
-      | sed -e 's/201[56789]-20[12][0-9]/YEARS/' -e 's/20[12][0-9]/YEARS/' \
+      | sed -e 's/20[12][0-9]-20[12][0-9]/YEARS/' -e 's/20[12][0-9]/YEARS/' \
       | shasum \
       | awk '{print $1}')
 


### PR DESCRIPTION
This PR adopts the changes introduced in https://github.com/grpc/grpc-swift/pull/2158, requiring client transports to provide a `ClientContext` alongside the stream.