### PR TITLE
Move test JSON (de)serializer to its own file

### DIFF
--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
@@ -133,22 +133,3 @@ enum CancellationKind: Codable {
 
 struct Empty: Codable {
 }
-
-struct JSONSerializer<Message: Encodable>: MessageSerializer {
-  private let encoder = JSONEncoder()
-
-  func serialize<Bytes: GRPCContiguousBytes>(_ message: Message) throws -> Bytes {
-    let data = try self.encoder.encode(message)
-    return Bytes(data)
-  }
-}
-
-struct JSONDeserializer<Message: Decodable>: MessageDeserializer {
-  private let decoder = JSONDecoder()
-
-  func deserialize<Bytes: GRPCContiguousBytes>(_ serializedMessageBytes: Bytes) throws -> Message {
-    try serializedMessageBytes.withUnsafeBytes {
-      try self.decoder.decode(Message.self, from: Data($0))
-    }
-  }
-}

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONSerializing.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONSerializing.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import GRPCCore
+
+struct JSONSerializer<Message: Encodable>: MessageSerializer {
+  private let encoder = JSONEncoder()
+
+  func serialize<Bytes: GRPCContiguousBytes>(_ message: Message) throws -> Bytes {
+    let data = try self.encoder.encode(message)
+    return Bytes(data)
+  }
+}
+
+struct JSONDeserializer<Message: Decodable>: MessageDeserializer {
+  private let decoder = JSONDecoder()
+
+  func deserialize<Bytes: GRPCContiguousBytes>(_ serializedMessageBytes: Bytes) throws -> Message {
+    try serializedMessageBytes.withUnsafeBytes {
+      try self.decoder.decode(Message.self, from: Data($0))
+    }
+  }
+}


### PR DESCRIPTION
This is a nit, but tests across different files are using `JSONSerializer` and `JSONDeserializer`, but it was defined at the bottom of one set of tests.
For tidiness and to improve discoverability a bit, they should be in their own file.