### PR TITLE
Remove workaround for issue #43

### DIFF
--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1392,8 +1392,6 @@ final class HTTP2TransportTests: XCTestCase {
       let request = ClientRequest(message: input)
       try await control.serverStream(request: request) { response in
         XCTAssertEqual(Array(response.metadata["echo-scheme"]), ["http"])
-        // Workaround https://github.com/grpc/grpc-swift-nio-transport/issues/43
-        for try await _ in response.messages {}
       }
     }
   }
@@ -1424,8 +1422,6 @@ final class HTTP2TransportTests: XCTestCase {
       }
       try await control.bidiStream(request: request) { response in
         XCTAssertEqual(Array(response.metadata["echo-scheme"]), ["http"])
-        // Workaround https://github.com/grpc/grpc-swift-nio-transport/issues/43
-        for try await _ in response.messages {}
       }
     }
   }


### PR DESCRIPTION
This has been resolved in https://github.com/apple/swift-nio/pull/3032 and the fix is present in NIO since 2.78.0, which this package already depends on. Removing workaround in tests.