### PR TITLE
Workaround nightly compiler crash

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -339,7 +339,8 @@ extension GRPCChannel {
           return
         }
 
-        let (enqueued, loadBalancer) = self.state.withLock { state in
+        // Explicitly adding the types works around: https://github.com/swiftlang/swift/issues/78112
+        let (enqueued, loadBalancer) = self.state.withLock { state -> (Bool, LoadBalancer?) in
           state.enqueue(continuation: continuation, waitForReady: waitForReady, id: id)
         }
 


### PR DESCRIPTION
Motivation:

Nightly toolchains are crashing when compiling this project. This is tracked in https://github.com/swiftlang/swift/issues/78112

Modifications:

- Add extra type info as this appears to work around the crash.

Result:

CI green on nightly toolchains.