### PR TITLE
Uncomment `StreamPriorityData` frames in stream handler tests

### DIFF
--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -40,10 +40,9 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     let framesToBeIgnored: [HTTP2Frame.FramePayload] = [
       .ping(.init(), ack: false),
       .goAway(lastStreamID: .rootStream, errorCode: .cancel, opaqueData: nil),
-      // TODO: uncomment when it's possible to build a `StreamPriorityData`.
-      // .priority(
-      //   HTTP2Frame.StreamPriorityData(exclusive: false, dependency: .rootStream, weight: 4)
-      // ),
+      .priority(
+        HTTP2Frame.StreamPriorityData(exclusive: false, dependency: .rootStream, weight: 4)
+      ),
       .settings(.ack),
       .pushPromise(.init(pushedStreamID: .maxID, headers: [:])),
       .windowUpdate(windowSizeIncrement: 4),

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -64,10 +64,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let framesToBeIgnored: [HTTP2Frame.FramePayload] = [
       .ping(.init(), ack: false),
       .goAway(lastStreamID: .rootStream, errorCode: .cancel, opaqueData: nil),
-      // TODO: uncomment when it's possible to build a `StreamPriorityData`.
-      // .priority(
-      //   HTTP2Frame.StreamPriorityData(exclusive: false, dependency: .rootStream, weight: 4)
-      // ),
+      .priority(
+        HTTP2Frame.StreamPriorityData(exclusive: false, dependency: .rootStream, weight: 4)
+      ),
       .settings(.ack),
       .pushPromise(.init(pushedStreamID: .maxID, headers: [:])),
       .windowUpdate(windowSizeIncrement: 4),


### PR DESCRIPTION
We had TODOs to uncomment some H2 frames in tests when their init became available, which it has. This PR uncomments them.