### PR TITLE
Ensure port isn't included in SNI hostname

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
@@ -23,10 +23,10 @@ package protocol HTTP2Connector: Sendable {
   ///
   /// - Parameters:
   ///   - address: The address to connect to.
-  ///   - authority: The authority as used for the TLS SNI extension (if applicable).
+  ///   - sniServerHostname: The name of the server used for the TLS SNI extension (if applicable).
   func establishConnection(
     to address: SocketAddress,
-    authority: String?
+    sniServerHostname: String?
   ) async throws -> HTTP2Connection
 }
 

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
@@ -165,7 +165,7 @@ extension HTTP2ClientTransport.Posix {
 
     func establishConnection(
       to address: GRPCNIOTransportCore.SocketAddress,
-      authority: String?
+      sniServerHostname: String?
     ) async throws -> HTTP2Connection {
       let (channel, multiplexer) = try await ClientBootstrap(
         group: self.eventLoopGroup
@@ -175,7 +175,7 @@ extension HTTP2ClientTransport.Posix {
             try channel.pipeline.syncOperations.addHandler(
               NIOSSLClientHandler(
                 context: sslContext,
-                serverHostname: authority
+                serverHostname: sniServerHostname
               )
             )
           }

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -149,7 +149,7 @@ extension HTTP2ClientTransport.TransportServices {
 
     func establishConnection(
       to address: GRPCNIOTransportCore.SocketAddress,
-      authority: String?
+      sniServerHostname: String?
     ) async throws -> HTTP2Connection {
       let bootstrap: NIOTSConnectionBootstrap
       let isPlainText: Bool
@@ -162,7 +162,7 @@ extension HTTP2ClientTransport.TransportServices {
       case .tls(let tlsConfig):
         isPlainText = false
         do {
-          let options = try NWProtocolTLS.Options(tlsConfig, authority: authority)
+          let options = try NWProtocolTLS.Options(tlsConfig, authority: sniServerHostname)
           bootstrap = NIOTSConnectionBootstrap(group: self.eventLoopGroup)
             .channelOption(NIOTSChannelOptions.waitForActivity, value: false)
             .tlsOptions(options)

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -232,6 +232,11 @@ final class ConnectionTests: XCTestCase {
       authority: "foo.example-31415",
       expected: "foo.example-31415"
     )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "foo.example.com:abc123",
+      expected: "foo.example.com:abc123"
+    )
   }
 }
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -21,6 +21,7 @@ import NIOCore
 import NIOHPACK
 import NIOHTTP2
 import NIOPosix
+import Synchronization
 import XCTest
 
 final class ConnectionTests: XCTestCase {
@@ -199,6 +200,39 @@ final class ConnectionTests: XCTestCase {
       XCTAssertEqual(error.code, .unavailable)
     }
   }
+
+  private func testAuthorityIsSanitized(authority: String, expected: String) async throws {
+    let recorder = SNIRecordingConnector()
+    let connection = Connection(
+      address: .ipv4(host: "ignored", port: 0),
+      authority: authority,
+      http2Connector: recorder,
+      defaultCompression: .none,
+      enabledCompression: .none
+    )
+
+    // The connect attempt will fail, but as a side effect the SNI hostname
+    // will be recorded.
+    await connection.run()
+    XCTAssertEqual(recorder.sniHostnames, [expected])
+  }
+
+  func testAuthorityIsSanitized() async throws {
+    try await self.testAuthorityIsSanitized(
+      authority: "foo.example.com",
+      expected: "foo.example.com"
+    )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "foo.example.com:31415",
+      expected: "foo.example.com"
+    )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "foo.example-31415",
+      expected: "foo.example-31415"
+    )
+  }
 }
 
 extension ClientBootstrap {
@@ -250,5 +284,27 @@ extension Metadata {
     }
 
     self = metadata
+  }
+}
+
+final class SNIRecordingConnector: HTTP2Connector {
+  private let _sniHostnames: Mutex<[String?]>
+
+  var sniHostnames: [String?] {
+    self._sniHostnames.withLock { $0 }
+  }
+
+  init() {
+    self._sniHostnames = Mutex([])
+  }
+
+  func establishConnection(
+    to address: GRPCNIOTransportCore.SocketAddress,
+    sniServerHostname: String?
+  ) async throws -> GRPCNIOTransportCore.HTTP2Connection {
+    self._sniHostnames.withLock {
+      $0.append(sniServerHostname)
+    }
+    throw RPCError(code: .unavailable, message: "Test is expected to throw.")
   }
 }

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
@@ -62,7 +62,7 @@ struct ThrowingConnector: HTTP2Connector {
 
   func establishConnection(
     to address: GRPCNIOTransportCore.SocketAddress,
-    authority: String?
+    sniServerHostname: String?
   ) async throws -> HTTP2Connection {
     throw self.error
   }
@@ -71,7 +71,7 @@ struct ThrowingConnector: HTTP2Connector {
 struct NeverConnector: HTTP2Connector {
   func establishConnection(
     to address: GRPCNIOTransportCore.SocketAddress,
-    authority: String?
+    sniServerHostname: String?
   ) async throws -> HTTP2Connection {
     fatalError("\(#function) called unexpectedly")
   }
@@ -103,7 +103,7 @@ struct NIOPosixConnector: HTTP2Connector {
 
   func establishConnection(
     to address: GRPCNIOTransportCore.SocketAddress,
-    authority: String?
+    sniServerHostname: String?
   ) async throws -> HTTP2Connection {
     return try await ClientBootstrap(group: self.eventLoopGroup).connect(to: address) { channel in
       channel.eventLoop.makeCompletedFuture {


### PR DESCRIPTION
Motivation:

gRPC derives the authority from various sources and uses this value for the SNI server hostname. The authority should include non-standard ports and the SNI hostname must not include the port. In some cases this wasn't being respected and the port was being used in SNI this results in handshake failures.

Modifications:

- Have the Connection sanitize the authority so that it's suitable for SNI.

Result:

- Fewer handshake failures
- Resolves #71