### PR TITLE
Fix build when using static Linux SDK

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
@@ -61,7 +61,7 @@ package enum DNSResolver {
     }
 
     var hints = addrinfo()
-    #if os(Linux)
+    #if os(Linux) && canImport(Glibc)
     hints.ai_socktype = CInt(SOCK_STREAM.rawValue)
     #else
     hints.ai_socktype = SOCK_STREAM


### PR DESCRIPTION
This fixes a build issue when using the static Linux SDK. We were branching on `#if os(Linux)` to decide whether a value we are using is an enum or a statically defined integer: Glibc declares it as an enum, whereas Darwin and Musl define it as an integer. We should make sure we are importing Glibc and not Musl when we consider it an enum, as otherwise the build will fail.