### PR TITLE
Apply patch to clamp window size to Int32.max

### DIFF
--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -205,6 +205,6 @@ extension ChannelPipeline.SynchronousOperations {
 
   /// Window size which mustn't exceed `2^31 - 1` (RFC 9113 § 6.5.2).
   internal func clampTargetWindowSize(_ targetWindowSize: Int) -> Int {
-    min(targetWindowSize, (1 << 31) - 1)
+    min(targetWindowSize, Int(Int32.max))
   }
 }


### PR DESCRIPTION
This prevents integer overflows from occurring on 32-bit architectures such as armv7. Could also work for i686, etc.

I also ran the test suite with this patch and all seems to work!