### PR TITLE
Fix minimum version of swift-nio-transport-services

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",
-    from: "1.15.0"
+    from: "1.20.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",


### PR DESCRIPTION
Motivation:

API from swift-nio-transport-services 1.20.0 is being used, but the minimum requirement is below this. This means builds can fail in some situations.

Modifications:

- Update minimum required version

Result:

Resolves #78