### PR TITLE
Expose the peerCertificate from mTLS to ServerContext

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    from: "2.0.0"
+    revision: "0d850d6"
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",
@@ -51,7 +51,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
-    from: "2.29.0"
+    revision: "874ad69"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",
@@ -60,6 +60,10 @@ let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-certificates.git",
     from: "1.5.0"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-asn1.git",
+    from: "1.0.0"
   ),
 ]
 
@@ -111,6 +115,9 @@ let targets: [Target] = [
       .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "NIOPosix", package: "swift-nio"),
       .product(name: "NIOSSL", package: "swift-nio-ssl"),
+      .product(name: "X509", package: "swift-certificates"),
+      .product(name: "SwiftASN1", package: "swift-asn1"),
+
     ],
     swiftSettings: defaultSwiftSettings
   ),

--- a/Package.swift
+++ b/Package.swift
@@ -117,7 +117,6 @@ let targets: [Target] = [
       .product(name: "NIOSSL", package: "swift-nio-ssl"),
       .product(name: "X509", package: "swift-certificates"),
       .product(name: "SwiftASN1", package: "swift-asn1"),
-
     ],
     swiftSettings: defaultSwiftSettings
   ),

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    revision: "0d850d6"
+    from: "2.2.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",
@@ -51,7 +51,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
-    revision: "874ad69"
+    from: "2.31.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -19,6 +19,7 @@ import GRPCCore
 import GRPCNIOTransportHTTP2Posix
 import GRPCNIOTransportHTTP2TransportServices
 import NIOSSL
+import SwiftASN1
 import Testing
 
 #if canImport(Network)
@@ -54,6 +55,63 @@ struct HTTP2TransportTLSEnabledTests {
     ) { control in
       await #expect(throws: Never.self) {
         try await self.executeUnaryRPC(control: control)
+      }
+    }
+  }
+
+  final class TransportSpecificInterceptor: ServerInterceptor {
+    let clientCert: [UInt8]
+    init(_ clientCert: [UInt8]) {
+      self.clientCert = clientCert
+    }
+    func intercept<Input, Output>(
+      request: GRPCCore.StreamingServerRequest<Input>,
+      context: GRPCCore.ServerContext,
+      next: @Sendable (GRPCCore.StreamingServerRequest<Input>, GRPCCore.ServerContext) async throws
+        -> GRPCCore.StreamingServerResponse<Output>
+    ) async throws -> GRPCCore.StreamingServerResponse<Output>
+    where Input: Sendable, Output: Sendable {
+      let transportSpecific = context.transportSpecific
+      #expect(transportSpecific != nil)
+      #expect(transportSpecific is HTTP2ServerTransport.Posix.Context)
+      let transportSpecificAsPosixContext = try #require(
+        transportSpecific as? HTTP2ServerTransport.Posix.Context
+      )
+      let peerCertificate = try #require(transportSpecificAsPosixContext.peerCertificate)
+      #expect(transportSpecificAsPosixContext.peerCertificate != nil)
+      var derSerializer = DER.Serializer()
+      try peerCertificate.serialize(into: &derSerializer)
+      #expect(derSerializer.serializedBytes == self.clientCert)
+      return try await next(request, context)
+    }
+  }
+
+  @Test(
+    "Using the mTLS defaults, and with Posix transport, validate we get the peer cert on the server",
+    arguments: TransportKind.supported
+  )
+  func testRPC_mTLS_TransportContext_OK(supportedTransport: TransportKind) async throws {
+    if TransportKind.posix == supportedTransport {
+      let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
+      let clientConfig = self.makeMTLSClientConfig(
+        for: supportedTransport,
+        certificateKeyPairs: certificateKeyPairs,
+        serverHostname: "localhost"
+      )
+      let serverConfig = self.makeMTLSServerConfig(
+        for: supportedTransport,
+        certificateKeyPairs: certificateKeyPairs,
+        includeClientCertificateInTrustRoots: true
+      )
+
+      try await self.withClientAndServer(
+        clientConfig: clientConfig,
+        serverConfig: serverConfig,
+        interceptors: [TransportSpecificInterceptor(certificateKeyPairs.client.certificate)]
+      ) { control in
+        await #expect(throws: Never.self) {
+          try await self.executeUnaryRPC(control: control)
+        }
       }
     }
   }
@@ -473,6 +531,7 @@ struct HTTP2TransportTLSEnabledTests {
   func withClientAndServer(
     clientConfig: ClientConfig,
     serverConfig: ServerConfig,
+    interceptors: [any ServerInterceptor] = [],
     _ test: (ControlClient<NIOClientTransport>) async throws -> Void
   ) async throws {
     let serverTransport: NIOServerTransport
@@ -497,7 +556,11 @@ struct HTTP2TransportTLSEnabledTests {
     #endif
     }
 
-    try await withGRPCServer(transport: serverTransport, services: [ControlService()]) { server in
+    try await withGRPCServer(
+      transport: serverTransport,
+      services: [ControlService()],
+      interceptors: interceptors
+    ) { server in
       guard let address = try await server.listeningAddress?.ipv4 else {
         throw TLSEnabledTestsError.unexpectedListeningAddress
       }


### PR DESCRIPTION
Motivation:

When using gRPC, it's useful to pull the peerCertificate from a successful mTLS connection for authn and/or authz.

Modifications:

These changes make use of the new transportSpecific field in the ServerContext. After a successful hanshake has completed, it uses the provided handler to retrieve the verified peer certificate and populate the Server Context.

There's also a simple happy path test that's been added for validation purposes.

Temporarily, this commit also references specific updates in swift-nio-ssl and grpc-swift.

Result:

This commit allows access to the swift Certificate object in an interceptor for the Posix HTTP2 transport. It also adds a mechanism for other transports to allow their own transport specific data.