### PR TITLE
Close request writer when finishing with an error

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -447,6 +447,9 @@ extension Connection {
       package func finish(throwing error: any Error) {
         // Fire the error inbound; this fails the inbound writer.
         self.http2Stream.channel.pipeline.fireErrorCaught(error)
+
+        // Now finish the request writer, to signal we're done writing.
+        self.requestWriter.finish()
       }
     }
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1674,6 +1674,50 @@ final class HTTP2TransportTests: XCTestCase {
       XCTAssertNotNil(peerInfo.client.local.wholeMatch(of: /unix:peer-info-uds/))
     }
   }
+
+  enum TestError: Error {
+    case someError
+  }
+
+  func testThrowingInClientStreamWriter() async throws {
+    let server = GRPCServer(
+      transport: .http2NIOPosix(
+        address: .ipv4(host: "127.0.0.1", port: 0),
+        transportSecurity: .plaintext
+      ),
+      services: [ControlService()]
+    )
+
+    try await withThrowingDiscardingTaskGroup { group in
+      group.addTask {
+        try await server.serve()
+      }
+
+      do {
+        try await withGRPCClient(
+          transport: NIOClientTransport(
+            .http2NIOPosix(
+              target: .dns(host: "localhost", port: server.listeningAddress!.ipv4!.port),
+              transportSecurity: .plaintext
+            )
+          )
+        ) { client in
+          let controlClient = ControlClient(wrapping: client)
+          _ = try await controlClient.clientStream(
+            request: .init(producer: { writer in
+              throw TestError.someError
+            })
+          )
+        }
+        XCTFail("Test should have failed")
+      } catch let error as RPCError {
+        XCTAssertEqual(error.code, .unavailable)
+        XCTAssertEqual(error.message, "Stream unexpectedly closed with error.")
+      }
+
+      server.beginGracefulShutdown()
+    }
+  }
 }
 
 extension [HTTP2TransportTests.Transport] {


### PR DESCRIPTION
As part of the investigation for https://github.com/grpc/grpc-swift-nio-transport/issues/95, we realised that the request writer would never be finished if an exception was thrown inside the writing closure. This PR adds a test reproducing this and makes sure the writer is properly finished.