### PR TITLE
Enable warnings as errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
 
   construct-integration-tests-matrix:
     name: Construct integration matrix

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
 
   construct-integration-tests-matrix:
     name: Construct integration matrix


### PR DESCRIPTION
Motivation:

It's generally helpful to avoid warnings. Currently there are zero warnings, we can avoid regressing this by enabling warnings as errors in CI.

Modifications:

- Enable warnings as errors

Result:

Harder to introduce warnings