### PR TITLE
Add a transport for wrapping a NIO Channel

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -506,8 +506,8 @@ extension Connection {
 
       init(_ connection: HTTP2Connection) {
         self.channel = connection.channel
-        self.remotePeer = connection.channel.remoteAddressInfo
-        self.localPeer = connection.channel.localAddressInfo
+        self.remotePeer = connection.channel.channel.remoteAddressInfo
+        self.localPeer = connection.channel.channel.localAddressInfo
         self.multiplexer = connection.multiplexer
         self.scheme = connection.isPlaintext ? .http : .https
         self.onCreateHTTP2Stream = connection.onCreateHTTP2Stream

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -604,7 +604,7 @@ extension GRPCChannel {
 
       struct NotRunning {
         /// Queue of requests waiting for a load-balancer.
-        var queue: RequestQueue
+        var queue: RequestQueue<LoadBalancer>
         /// A handle to the name resolver task.
         var nameResolverHandle: CancellableTaskHandle?
 
@@ -624,7 +624,7 @@ extension GRPCChannel {
         /// Previously created load-balancers which are in the process of shutting down.
         var past: [LoadBalancerID: LoadBalancer]
         /// Queue of requests wait for a load-balancer.
-        var queue: RequestQueue
+        var queue: RequestQueue<LoadBalancer>
         /// A handle to the name resolver task.
         var nameResolverHandle: CancellableTaskHandle?
 
@@ -950,8 +950,13 @@ extension GRPCChannel.StateMachine {
 
   enum OnClose {
     case none
-    case cancelAll([RequestQueue.Continuation])
-    case close(LoadBalancer, LoadBalancer?, CancellableTaskHandle?, [RequestQueue.Continuation])
+    case cancelAll([RequestQueue<LoadBalancer>.Continuation])
+    case close(
+      LoadBalancer,
+      LoadBalancer?,
+      CancellableTaskHandle?,
+      [RequestQueue<LoadBalancer>.Continuation]
+    )
   }
 
   mutating func close() -> OnClose {

--- a/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
@@ -16,8 +16,8 @@
 
 internal import DequeModule
 
-struct RequestQueue {
-  typealias Continuation = CheckedContinuation<LoadBalancer, any Error>
+struct RequestQueue<Element> {
+  typealias Continuation = CheckedContinuation<Element, any Error>
 
   private struct QueueEntry {
     var continuation: Continuation

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
@@ -38,7 +38,7 @@ extension HTTP2ClientTransport.WrappedChannel {
     ///   - compression: Compression configuration.
     ///   - channelDebuggingCallbacks: Channel callbacks for debugging.
     ///
-    /// - SeeAlso: ``defaults(configure:)`` and ``defaults``.
+    /// - SeeAlso: ``defaults(_:)`` and ``defaults``.
     public init(
       http2: HTTP2ClientTransport.Config.HTTP2,
       connection: HTTP2ClientTransport.Config.Connection,

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public import NIOCore
+
+extension HTTP2ClientTransport.WrappedChannel {
+  public struct Config: Sendable {
+    /// Configuration for HTTP/2 connections.
+    public var http2: HTTP2ClientTransport.Config.HTTP2
+
+    /// Configuration for connection management.
+    public var connection: HTTP2ClientTransport.Config.Connection
+
+    /// Compression configuration.
+    public var compression: HTTP2ClientTransport.Config.Compression
+
+    /// Channel callbacks for debugging.
+    public var channelDebuggingCallbacks: ChannelDebuggingCallbacks
+
+    /// Creates a new connection configuration.
+    ///
+    /// - Parameters:
+    ///   - http2: HTTP2 configuration.
+    ///   - connection: Connection configuration.
+    ///   - compression: Compression configuration.
+    ///   - channelDebuggingCallbacks: Channel callbacks for debugging.
+    ///
+    /// - SeeAlso: ``defaults(configure:)`` and ``defaults``.
+    public init(
+      http2: HTTP2ClientTransport.Config.HTTP2,
+      connection: HTTP2ClientTransport.Config.Connection,
+      compression: HTTP2ClientTransport.Config.Compression,
+      channelDebuggingCallbacks: ChannelDebuggingCallbacks
+    ) {
+      self.http2 = http2
+      self.connection = connection
+      self.compression = compression
+      self.channelDebuggingCallbacks = channelDebuggingCallbacks
+    }
+
+    /// Default configuration.
+    public static var defaults: Self {
+      Self.defaults { _ in }
+    }
+
+    /// Default values.
+    ///
+    /// - Parameters:
+    ///   - configure: A closure which allows you to modify the defaults before returning them.
+    public static func defaults(_ configure: (inout Self) -> Void) -> Self {
+      var config = Self(
+        http2: .defaults,
+        connection: .defaults,
+        compression: .defaults,
+        channelDebuggingCallbacks: .defaults
+      )
+      configure(&config)
+      return config
+    }
+  }
+}
+
+extension HTTP2ClientTransport.WrappedChannel.Config {
+  /// Callbacks used for debugging purposes.
+  ///
+  /// The callbacks give you access to the underlying NIO `Channel` after gRPC's initializer has
+  /// run for each `Channel`. These callbacks are intended for debugging purposes.
+  ///
+  /// - Important: You should be very careful when implementing these callbacks as they may have
+  ///   unexpected side effects on your gRPC application.
+  public struct ChannelDebuggingCallbacks: Sendable {
+    /// A callback invoked with each new HTTP/2 stream.
+    public var onCreateHTTP2Stream: (@Sendable (_ channel: any Channel) -> EventLoopFuture<Void>)?
+
+    public init(
+      onCreateHTTP2Stream: (@Sendable (_ channel: any Channel) -> EventLoopFuture<Void>)?
+    ) {
+      self.onCreateHTTP2Stream = onCreateHTTP2Stream
+    }
+
+    /// Default values; no callbacks are set.
+    public static var defaults: Self {
+      Self(onCreateHTTP2Stream: nil)
+    }
+  }
+}
+
+extension GRPCChannel.Config {
+  init(_ config: HTTP2ClientTransport.WrappedChannel.Config) {
+    self.init(
+      http2: config.http2,
+      // This won't be used, the channel is already connected and can never reconnect.
+      backoff: .defaults,
+      connection: config.connection,
+      compression: config.compression
+    )
+  }
+}

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+State.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+State.swift
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal import GRPCCore
+internal import NIOHTTP2
+
+extension HTTP2ClientTransport.WrappedChannel {
+  enum State: ~Copyable {
+    case idle(Idle)
+    case configuring(Configuring)
+    case configured(Configured)
+    case ready(Ready)
+    case shuttingDown
+    case shutDown
+
+    struct Idle: ~Copyable {
+      var queue: RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>
+
+      init() {
+        self.queue = RequestQueue()
+      }
+    }
+
+    struct Configuring: ~Copyable {
+      var queue: RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>
+
+      init(from state: consuming Idle) {
+        self.queue = state.queue
+      }
+    }
+
+    struct Configured: ~Copyable {
+      var queue: RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>
+      var multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+
+      init(
+        from state: consuming Configuring,
+        multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+      ) {
+        self.queue = state.queue
+        self.multiplexer = multiplexer
+      }
+    }
+
+    struct Ready: ~Copyable {
+      var multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+
+      init(from state: consuming Configured) {
+        self.multiplexer = state.multiplexer
+      }
+    }
+
+    init() {
+      self = .idle(Idle())
+    }
+  }
+}
+
+extension HTTP2ClientTransport.WrappedChannel.State {
+  enum ConnectAction {
+    case configureChannel
+    case `return`
+  }
+
+  mutating func connect() -> ConnectAction {
+    switch consume self {
+    case .idle(let state):
+      self = .configuring(Configuring(from: state))
+      return .configureChannel
+
+    case .configuring(let state):
+      self = .configuring(state)
+      return .return
+
+    case .configured(let state):
+      self = .configured(state)
+      return .return
+
+    case .ready(let state):
+      self = .ready(state)
+      return .return
+
+    case .shuttingDown:
+      self = .shuttingDown
+      return .return
+
+    case .shutDown:
+      self = .shutDown
+      return .return
+    }
+  }
+
+  enum ChannelConfiguredAction {
+    case `continue`
+    case shutDown
+  }
+
+  mutating func channelConfigured(
+    multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>?
+  ) -> ChannelConfiguredAction {
+    let action: ChannelConfiguredAction
+
+    switch consume self {
+    case .configuring(let state):
+      if let multiplexer = multiplexer {
+        self = .configured(Configured(from: state, multiplexer: multiplexer))
+        action = .continue
+      } else {
+        self = .shutDown
+        action = .shutDown
+      }
+
+    case .shuttingDown:
+      // Either way, close the channel.
+      self = .shuttingDown
+      action = .shutDown
+
+    case .idle:
+      fatalError("Invalid state")
+
+    case .configured:
+      fatalError("Invalid state")
+
+    case .ready:
+      fatalError("Invalid state")
+
+    case .shutDown:
+      fatalError("Invalid state")
+    }
+
+    return action
+  }
+
+  enum ReadyAction {
+    case none
+    case resume(
+      continuations: [RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>.Continuation],
+      multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+    )
+  }
+
+  mutating func ready() -> ReadyAction {
+    switch consume self {
+    case .configured(var state):
+      let continuations = state.queue.removeAll()
+      let multiplexer = state.multiplexer
+      self = .ready(Ready(from: state))
+      return .resume(continuations: continuations, multiplexer: multiplexer)
+
+    case .shuttingDown:
+      self = .shuttingDown
+      return .none
+
+    case .idle:
+      fatalError("Invalid state")
+
+    case .configuring:
+      fatalError("Invalid state")
+
+    case .ready:
+      fatalError("Invalid state")
+
+    case .shutDown:
+      fatalError("Invalid state")
+    }
+  }
+
+  enum BeginGracefulShutDownAction {
+    case none
+    case emitGracefulShutdownEvent
+  }
+
+  mutating func beginGracefulShutdown() -> BeginGracefulShutDownAction {
+    let action: BeginGracefulShutDownAction
+
+    switch consume self {
+    case .idle:
+      self = .shutDown
+      action = .none
+
+    case .configuring:
+      self = .shuttingDown
+      action = .none
+
+    case .configured:
+      self = .shuttingDown
+      action = .emitGracefulShutdownEvent
+
+    case .ready:
+      self = .shuttingDown
+      action = .emitGracefulShutdownEvent
+
+    case .shuttingDown:
+      self = .shuttingDown
+      action = .none
+
+    case .shutDown:
+      self = .shutDown
+      action = .none
+    }
+
+    return action
+  }
+
+  enum ConnectionClosedAction {
+    case none
+    case failQueuedStreams
+  }
+
+  mutating func connectionClosed() -> ConnectionClosedAction {
+    switch consume self {
+    case .idle:
+      self = .shutDown
+      return .none
+
+    case .configuring:
+      self = .shutDown
+      return .failQueuedStreams
+
+    case .configured:
+      self = .shutDown
+      return .failQueuedStreams
+
+    case .ready:
+      self = .shutDown
+      return .failQueuedStreams
+
+    case .shuttingDown:
+      self = .shuttingDown
+      return .none
+
+    case .shutDown:
+      self = .shutDown
+      return .none
+    }
+  }
+
+  enum CreateStreamAction {
+    case enqueue
+    case create(NIOHTTP2Handler.AsyncStreamMultiplexer<Void>)
+    case `throw`(RPCError)
+  }
+
+  mutating func createStream() -> CreateStreamAction {
+    switch self {
+    case .idle:
+      return .enqueue
+    case .configuring:
+      return .enqueue
+    case .configured:
+      return .enqueue
+    case .ready(let state):
+      return .create(state.multiplexer)
+    case .shuttingDown:
+      return .throw(RPCError(code: .unavailable, message: "Transport is shut down."))
+    case .shutDown:
+      return .throw(RPCError(code: .unavailable, message: "Transport is shut down."))
+    }
+  }
+
+  enum EnqueueAction {
+    case none
+    case resume(Result<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>, RPCError>)
+  }
+
+  mutating func enqueue(
+    continuation: RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>.Continuation,
+    withID id: QueueEntryID
+  ) -> EnqueueAction {
+    let action: EnqueueAction
+
+    switch consume self {
+    case .idle(var state):
+      state.queue.append(continuation: continuation, waitForReady: true, id: id)
+      action = .none
+      self = .idle(state)
+
+    case .configuring(var state):
+      state.queue.append(continuation: continuation, waitForReady: true, id: id)
+      action = .none
+      self = .configuring(state)
+
+    case .configured(var state):
+      state.queue.append(continuation: continuation, waitForReady: true, id: id)
+      action = .none
+      self = .configured(state)
+
+    case .ready(let state):
+      action = .resume(.success(state.multiplexer))
+      self = .ready(state)
+
+    case .shuttingDown:
+      let error = RPCError(code: .unavailable, message: "Transport is shutting down.")
+      action = .resume(.failure(error))
+      self = .shuttingDown
+
+    case .shutDown:
+      let error = RPCError(code: .unavailable, message: "Transport is shut down.")
+      action = .resume(.failure(error))
+      self = .shutDown
+    }
+
+    return action
+  }
+
+  enum DequeueAction {
+    case dequeued(RequestQueue<NIOHTTP2Handler.AsyncStreamMultiplexer<Void>>.Continuation)
+    case none
+  }
+
+  mutating func dequeue(id: QueueEntryID) -> DequeueAction {
+    let action: DequeueAction
+
+    switch consume self {
+    case .idle(var state):
+      let continuation = state.queue.removeEntry(withID: id)
+      action = continuation.map { .dequeued($0) } ?? .none
+      self = .idle(state)
+
+    case .configuring(var state):
+      let continuation = state.queue.removeEntry(withID: id)
+      action = continuation.map { .dequeued($0) } ?? .none
+      self = .configuring(state)
+
+    case .configured(var state):
+      let continuation = state.queue.removeEntry(withID: id)
+      action = continuation.map { .dequeued($0) } ?? .none
+      self = .configured(state)
+
+    case .ready(let state):
+      self = .ready(state)
+      action = .none
+
+    case .shuttingDown:
+      self = .shuttingDown
+      action = .none
+
+    case .shutDown:
+      self = .shutDown
+      action = .none
+    }
+
+    return action
+  }
+}

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
@@ -58,7 +58,7 @@ extension HTTP2ClientTransport {
       4 * 1024 * 1024
     }
 
-    /// Create a new wrapping client transport from an already connection NIO `Channel`.
+    /// Create a new wrapping client transport from an already connected NIO `Channel`.
     ///
     /// - Parameters:
     ///   - channel: The channel to wrap. The transport takes ownership of the lifetime of the channel
@@ -154,7 +154,7 @@ extension HTTP2ClientTransport {
       switch self.state.withLock({ $0.beginGracefulShutdown() }) {
       case .emitGracefulShutdownEvent:
         // Fire an event into the channel. At this point it will have been configured for gRPC
-        // and an appropriate channel handler will consumer it to start the graceful shutdown
+        // and an appropriate channel handler will consume it to start the graceful shutdown
         // flow.
         let event = ClientConnectionHandler.OutboundEvent.closeGracefully
         self.channel.triggerUserOutboundEvent(event, promise: nil)

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public import GRPCCore
+public import NIOCore
+internal import NIOHTTP2
+private import Synchronization
+
+/// A client transport which wraps an existing SwiftNIO `Channel`.
+///
+/// You can use this if you already have a connected `Channel` that you'd like to use as a gRPC
+/// client connection. This is helpful if, for example, you wish to tunnel gRPC inside another
+/// protocol. This approach has limitations: as the pre-connected `Channel` is provided to gRPC
+/// it isn't possible to transparently reconnect should the connection close. As such this transport
+/// offers fewer features than its regular NIO based counterparts.
+///
+/// ## Providing a suitable Channel
+///
+/// The transport will add a number of channel handlers to the end of the pipeline of the provided
+/// channel. You must ensure that the final channel handler (before being passed into the transport)
+/// uses `ByteBuffer` as its `InboundIn` and `OutboundOut` types.
+///
+/// If you require TLS then it's your responsibility to ensure that the channel is already
+/// appropriately configured to use it.
+///
+/// ## Lifecycle
+///
+/// By providing a channel to this transport you hand ownership of it to the transport. The
+/// transport therefore becomes responsible for closing the channel at the appropriate point
+/// in time.
+extension HTTP2ClientTransport {
+  public final class WrappedChannel: ClientTransport {
+    public typealias Bytes = GRPCNIOTransportBytes
+
+    private let channel: any Channel
+    private let serviceConfig: ServiceConfig
+    private let methodConfig: MethodConfigs
+    private let config: Config
+    private let state: Mutex<State>
+
+    public let retryThrottle: RetryThrottle?
+
+    /// The default max request message size in bytes, 4 MiB.
+    private static var defaultMaxRequestMessageSizeBytes: Int {
+      4 * 1024 * 1024
+    }
+
+    /// Create a new wrapping client transport from an already connection NIO `Channel`.
+    ///
+    /// - Parameters:
+    ///   - channel: The channel to wrap. The transport takes ownership of the lifetime of the channel
+    ///       from this point onwards and is responsible for closing it when the transport is
+    ///       finished.
+    ///   - config: Configuration for the transport.
+    ///   - serviceConfig: Service config controlling how the transport should handle individual
+    ///       methods and throttle retries. Note that load-balancing policies are ignored by this
+    ///       transport.
+    public init(
+      takingOwnershipOf channel: consuming any Channel,
+      config: Config = .defaults,
+      serviceConfig: ServiceConfig = ServiceConfig()
+    ) {
+      self.channel = channel
+      self.serviceConfig = serviceConfig
+      self.methodConfig = MethodConfigs(serviceConfig: serviceConfig)
+      self.config = config
+      self.state = Mutex(State())
+
+      if let throttleConfig = serviceConfig.retryThrottling {
+        self.retryThrottle = RetryThrottle(policy: throttleConfig)
+      } else {
+        self.retryThrottle = nil
+      }
+    }
+
+    public func config(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
+      return self.methodConfig[descriptor]
+    }
+
+    public func connect() async throws {
+      switch self.state.withLock({ $0.connect() }) {
+      case .configureChannel:
+        ()
+      case .return:
+        return
+      }
+
+      do {
+        let (connection, streamMultiplexer) = try await self.channel.eventLoop.submit {
+          let config = GRPCChannel.Config(self.config)
+          let sync = self.channel.pipeline.syncOperations
+          return try sync.configureGRPCClientPipeline(channel: self.channel, config: config)
+        }.get()
+
+        switch self.state.withLock({ $0.channelConfigured(multiplexer: streamMultiplexer) }) {
+        case .continue:
+          // Add a task to run the connection and consume events.
+          try? await connection.executeThenClose { inbound, outbound in
+            for try await event in inbound {
+              switch event {
+              case .ready:
+                // Start doing RPCs.
+                switch self.state.withLock({ $0.ready() }) {
+                case .resume(let continuations, let multiplexer):
+                  for continuation in continuations {
+                    continuation.resume(returning: multiplexer)
+                  }
+                case .none:
+                  ()
+                }
+
+              case .closing:
+                ()
+              }
+            }
+          }
+
+          switch self.state.withLock({ $0.connectionClosed() }) {
+          case .none:
+            ()
+          case .failQueuedStreams:
+            ()
+          }
+
+        case .shutDown:
+          try await self.channel.close()
+        }
+      } catch {
+        switch self.state.withLock({ $0.channelConfigured(multiplexer: nil) }) {
+        case .continue:
+          ()
+        case .shutDown:
+          try? await channel.close()
+        }
+        // Throw the original error.
+        throw error
+      }
+    }
+
+    public func beginGracefulShutdown() {
+      switch self.state.withLock({ $0.beginGracefulShutdown() }) {
+      case .emitGracefulShutdownEvent:
+        // Fire an event into the channel. At this point it will have been configured for gRPC
+        // and an appropriate channel handler will consumer it to start the graceful shutdown
+        // flow.
+        let event = ClientConnectionHandler.OutboundEvent.closeGracefully
+        self.channel.triggerUserOutboundEvent(event, promise: nil)
+      case .none:
+        ()
+      }
+    }
+
+    public func withStream<T>(
+      descriptor: MethodDescriptor,
+      options: CallOptions,
+      _ closure: (RPCStream<Inbound, Outbound>, ClientContext) async throws -> T
+    ) async throws -> T where T: Sendable {
+      let multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+
+      switch self.state.withLock({ $0.createStream() }) {
+      case .create(let mux):
+        multiplexer = mux
+
+      case .throw(let error):
+        throw error
+
+      case .enqueue:
+        // The transport isn't ready yet: queue the stream.
+        let id = QueueEntryID()
+        multiplexer = try await withTaskCancellationHandler {
+          try await withCheckedThrowingContinuation { continuation in
+            let action = self.state.withLock {
+              $0.enqueue(continuation: continuation, withID: id)
+            }
+
+            switch action {
+            case .resume(.success(let multiplexer)):
+              continuation.resume(returning: multiplexer)
+            case .resume(.failure(let error)):
+              continuation.resume(throwing: error)
+            case .none:
+              ()
+            }
+          }
+        } onCancel: {
+          let action = self.state.withLock { $0.dequeue(id: id) }
+          switch action {
+          case .dequeued(let continuation):
+            continuation.resume(throwing: CancellationError())
+          case .none:
+            ()
+          }
+        }
+      }
+
+      let stream = try await self.makeStream(
+        on: multiplexer,
+        descriptor: descriptor,
+        options: options
+      )
+
+      return try await stream.execute { inbound, outbound in
+        let rpcStream = RPCStream(
+          descriptor: stream.context.descriptor,
+          inbound: RPCAsyncSequence<RPCResponsePart, any Error>(wrapping: inbound),
+          outbound: RPCWriter.Closable(wrapping: outbound)
+        )
+        return try await closure(rpcStream, stream.context)
+      }
+    }
+
+    private func makeStream(
+      on multiplexer: NIOHTTP2Handler.AsyncStreamMultiplexer<Void>,
+      descriptor: MethodDescriptor,
+      options: CallOptions
+    ) async throws(RPCError) -> Connection.Stream {
+      // Merge options from the call with those from the service config.
+      let methodConfig = self.config(forMethod: descriptor)
+      var options = options
+      options.formUnion(with: methodConfig)
+
+      let compression: CompressionAlgorithm
+      if let override = options.compression {
+        compression =
+          self.config.compression.enabledAlgorithms.contains(override) ? override : .none
+      } else {
+        compression = self.config.compression.algorithm
+      }
+
+      let maxRequestSize = options.maxRequestMessageBytes ?? Self.defaultMaxRequestMessageSizeBytes
+
+      do {
+        let stream = try await multiplexer.openStream { channel in
+          channel.eventLoop.makeCompletedFuture {
+            let streamHandler = GRPCClientStreamHandler(
+              methodDescriptor: descriptor,
+              scheme: .http,
+              // The value of authority here is being used for the ":authority" pseudo-header. Derive
+              // one from the address if we don't already have one.
+              authority: self.config.http2.authority,
+              outboundEncoding: compression,
+              acceptedEncodings: self.config.compression.enabledAlgorithms,
+              maxPayloadSize: maxRequestSize
+            )
+            try channel.pipeline.syncOperations.addHandler(streamHandler)
+
+            return try NIOAsyncChannel(
+              wrappingChannelSynchronously: channel,
+              configuration: NIOAsyncChannel.Configuration(
+                isOutboundHalfClosureEnabled: true,
+                inboundType: RPCResponsePart<GRPCNIOTransportBytes>.self,
+                outboundType: RPCRequestPart<GRPCNIOTransportBytes>.self
+              )
+            )
+          }.runInitializerIfSet(
+            self.config.channelDebuggingCallbacks.onCreateHTTP2Stream,
+            on: channel
+          )
+        }
+
+        let context = ClientContext(
+          descriptor: descriptor,
+          remotePeer: self.channel.remoteAddressInfo,
+          localPeer: self.channel.localAddressInfo
+        )
+
+        return Connection.Stream(wrapping: stream, context: context)
+      } catch {
+        throw RPCError(code: .unavailable, message: "subchannel is unavailable", cause: error)
+      }
+    }
+  }
+}
+
+extension ClientTransport where Self == HTTP2ClientTransport.WrappedChannel {
+  /// Create a new wrapping client transport from an already connection NIO `Channel`.
+  ///
+  /// - Parameters:
+  ///   - channel: The channel to wrap. The transport takes ownership of the lifetime of the channel
+  ///       from this point onwards and is responsible for closing it when the transport is
+  ///       finished.
+  ///   - config: Configuration for the transport.
+  ///   - serviceConfig: Service config controlling how the transport should handle individual
+  ///       methods and throttle retries. Note that load-balancing policies are ignored by this
+  ///       transport.
+  public static func wrapping(
+    channel: consuming any Channel,
+    config: HTTP2ClientTransport.WrappedChannel.Config = .defaults,
+    serviceConfig: ServiceConfig = ServiceConfig()
+  ) -> Self {
+    HTTP2ClientTransport.WrappedChannel(
+      takingOwnershipOf: channel,
+      config: config,
+      serviceConfig: serviceConfig
+    )
+  }
+}

--- a/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
@@ -16,18 +16,18 @@
 
 internal import NIOCore
 
-extension NIOAsyncChannel {
+extension Channel {
   var remoteAddressInfo: String {
     self.getAddressInfoWithFallbackIfUDS(
-      address: self.channel.remoteAddress,
-      udsFallback: self.channel.localAddress
+      address: self.remoteAddress,
+      udsFallback: self.localAddress
     )
   }
 
   var localAddressInfo: String {
     self.getAddressInfoWithFallbackIfUDS(
-      address: self.channel.localAddress,
-      udsFallback: self.channel.remoteAddress
+      address: self.localAddress,
+      udsFallback: self.remoteAddress
     )
   }
 

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -209,8 +209,8 @@ package final class CommonHTTP2ServerTransport<
       _ context: ServerContext
     ) async -> Void
   ) async throws {
-    let remotePeer = connection.remoteAddressInfo
-    let localPeer = connection.localAddressInfo
+    let remotePeer = connection.channel.remoteAddressInfo
+    let localPeer = connection.channel.localAddressInfo
     try await connection.executeThenClose { inbound, _ in
       await withDiscardingTaskGroup { group in
         group.addTask {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
@@ -24,13 +24,13 @@ final class RequestQueueTests: XCTestCase {
   struct AnErrorToAvoidALeak: Error {}
 
   func testPopFirstEmpty() {
-    var queue = RequestQueue()
+    var queue = RequestQueue<Int>()
     XCTAssertNil(queue.popFirst())
   }
 
   func testPopFirstNonEmpty() async {
     _ = try? await withCheckedThrowingContinuation { continuation in
-      var queue = RequestQueue()
+      var queue = RequestQueue<Int>()
       let id = QueueEntryID()
 
       queue.append(continuation: continuation, waitForReady: false, id: id)
@@ -95,7 +95,7 @@ final class RequestQueueTests: XCTestCase {
 
   func testRemoveEntryByID() async {
     _ = try? await withCheckedThrowingContinuation { continuation in
-      var queue = RequestQueue()
+      var queue = RequestQueue<Int>()
       let id = QueueEntryID()
 
       queue.append(continuation: continuation, waitForReady: false, id: id)
@@ -258,13 +258,15 @@ final class RequestQueueTests: XCTestCase {
   }
 
   final class SharedRequestQueue: Sendable {
-    private let protectedQueue: Mutex<RequestQueue>
+    private let protectedQueue: Mutex<RequestQueue<LoadBalancer>>
 
     init() {
       self.protectedQueue = Mutex(RequestQueue())
     }
 
-    func withQueue<T>(_ body: @Sendable (inout RequestQueue) throws -> T) rethrows -> T {
+    func withQueue<T>(
+      _ body: @Sendable (inout RequestQueue<LoadBalancer>) throws -> T
+    ) rethrows -> T {
       try self.protectedQueue.withLock {
         try body(&$0)
       }

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
@@ -124,6 +124,9 @@ struct ChannelDebugCallbackTests {
         )
       )
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 
@@ -155,6 +158,9 @@ struct ChannelDebugCallbackTests {
         )
       )
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
@@ -22,7 +22,7 @@ import Testing
 
 @Suite("ChannelDebugCallbacks")
 struct ChannelDebugCallbackTests {
-  @Test(arguments: TransportKind.allCases, TransportKind.allCases)
+  @Test(arguments: TransportKind.supportsDebugCallbacks, TransportKind.supportsDebugCallbacks)
   func debugCallbacksAreCalled(serverKind: TransportKind, clientKind: TransportKind) async throws {
     // Validates the callbacks are called appropriately by setting up callbacks which increment
     // counters and then returning those stats from a gRPC service. The client's interactions with

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -32,8 +32,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "When using defaults, server does not perform client verification",
-    arguments: TransportKind.supported,
-    TransportKind.supported
+    arguments: TransportKind.clientsWithTLS,
+    TransportKind.serversWithTLS
   )
   func testRPC_Defaults_OK(
     clientTransport: TransportKind,
@@ -113,8 +113,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "When using mTLS defaults, both client and server verify each others' certificates",
-    arguments: TransportKind.supported,
-    TransportKind.supported
+    arguments: TransportKind.clientsWithTLS,
+    TransportKind.clientsWithTLS
   )
   func testRPC_mTLS_OK(
     clientTransport: TransportKind,
@@ -144,8 +144,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "Error is surfaced when client fails server verification",
-    arguments: TransportKind.supported,
-    TransportKind.supported
+    arguments: TransportKind.clientsWithTLS,
+    TransportKind.clientsWithTLS
   )
   // Verification should fail because the custom hostname is missing on the client.
   func testClientFailsServerValidation(
@@ -199,6 +199,9 @@ struct HTTP2TransportTLSEnabledTests {
           return false
         }
       #endif
+
+      case .wrappedChannel:
+        fatalError("Unsupported")
       }
 
       return true
@@ -207,8 +210,8 @@ struct HTTP2TransportTLSEnabledTests {
 
   @Test(
     "Error is surfaced when server fails client verification",
-    arguments: TransportKind.supported,
-    TransportKind.supported
+    arguments: TransportKind.clientsWithTLS,
+    TransportKind.clientsWithTLS
   )
   // Verification should fail because the client does not offer a cert that
   // the server can use for mutual verification.
@@ -271,6 +274,9 @@ struct HTTP2TransportTLSEnabledTests {
           return false
         }
       #endif
+
+      case .wrappedChannel:
+        fatalError("Unsupported")
       }
 
       return true
@@ -372,6 +378,9 @@ struct HTTP2TransportTLSEnabledTests {
       config.transport.http2.authority = authority
       return .transportServices(config)
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 
@@ -443,6 +452,9 @@ struct HTTP2TransportTLSEnabledTests {
       config.transport.http2.authority = serverHostname
       return .transportServices(config)
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 
@@ -480,6 +492,9 @@ struct HTTP2TransportTLSEnabledTests {
       }
       return .transportServices(config)
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 
@@ -520,6 +535,9 @@ struct HTTP2TransportTLSEnabledTests {
       }
       return .transportServices(config)
     #endif
+
+    case .wrappedChannel:
+      fatalError("Unsupported")
     }
   }
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -1732,11 +1732,11 @@ final class HTTP2TransportTests: XCTestCase {
 }
 
 extension [HTTP2TransportTests.Transport] {
-   static let supported: [HTTP2TransportTests.Transport] = TransportKind.servers.flatMap { server in
-     TransportKind.clients.map { client in
-       HTTP2TransportTests.Transport(server: server, client: client)
-     }
-   }
+  static let supported: [HTTP2TransportTests.Transport] = TransportKind.servers.flatMap { server in
+    TransportKind.clients.map { client in
+      HTTP2TransportTests.Transport(server: server, client: client)
+    }
+  }
 }
 
 extension ControlInput {

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
@@ -39,6 +39,10 @@ enum TransportKind: CaseIterable, Hashable, Sendable {
   static var serversWithTLS: [Self] {
     Self.allCases.filter { $0 != .wrappedChannel }
   }
+
+  static var supportsDebugCallbacks: [Self] {
+    Self.allCases.filter { $0 != .wrappedChannel }
+  }
 }
 
 enum NIOClientTransport: ClientTransport {

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
@@ -18,21 +18,39 @@ import GRPCCore
 import GRPCNIOTransportHTTP2
 
 enum TransportKind: CaseIterable, Hashable, Sendable {
+  case wrappedChannel
   case posix
   #if canImport(Network)
   case transportServices
   #endif
 
-  static var supported: [Self] {
+  static var clients: [Self] {
     Self.allCases
+  }
+
+  static var clientsWithTLS: [Self] {
+    Self.allCases.filter { $0 != .wrappedChannel }
+  }
+
+  static var servers: [Self] {
+    Self.allCases.filter { $0 != .wrappedChannel }
+  }
+
+  static var serversWithTLS: [Self] {
+    Self.allCases.filter { $0 != .wrappedChannel }
   }
 }
 
 enum NIOClientTransport: ClientTransport {
+  case wrappedChannel(HTTP2ClientTransport.WrappedChannel)
   case posix(HTTP2ClientTransport.Posix)
   #if canImport(Network)
   case transportServices(HTTP2ClientTransport.TransportServices)
   #endif
+
+  init(_ transport: HTTP2ClientTransport.WrappedChannel) {
+    self = .wrappedChannel(transport)
+  }
 
   init(_ transport: HTTP2ClientTransport.Posix) {
     self = .posix(transport)
@@ -54,6 +72,8 @@ enum NIOClientTransport: ClientTransport {
     case .transportServices(let transport):
       return transport.retryThrottle
     #endif
+    case .wrappedChannel(let transport):
+      return transport.retryThrottle
     }
   }
 
@@ -65,6 +85,8 @@ enum NIOClientTransport: ClientTransport {
     case .transportServices(let transport):
       try await transport.connect()
     #endif
+    case .wrappedChannel(let transport):
+      try await transport.connect()
     }
   }
 
@@ -76,6 +98,8 @@ enum NIOClientTransport: ClientTransport {
     case .transportServices(let transport):
       transport.beginGracefulShutdown()
     #endif
+    case .wrappedChannel(let transport):
+      transport.beginGracefulShutdown()
     }
   }
 
@@ -91,6 +115,8 @@ enum NIOClientTransport: ClientTransport {
     case .transportServices(let transport):
       return try await transport.withStream(descriptor: descriptor, options: options, closure)
     #endif
+    case .wrappedChannel(let transport):
+      return try await transport.withStream(descriptor: descriptor, options: options, closure)
     }
   }
 
@@ -102,6 +128,8 @@ enum NIOClientTransport: ClientTransport {
     case .transportServices(let transport):
       return transport.config(forMethod: descriptor)
     #endif
+    case .wrappedChannel(let transport):
+      return transport.config(forMethod: descriptor)
     }
   }
 


### PR DESCRIPTION
Motivation:

The NIO based client and transports want to fully manage the underlying NIO channels for you; creating them and tearing them down as necessary. However, in some instances users already have a NIO channel which they may also want to use a client. This might happen if they want to run gRPC within another protocol, for example.

Modifications:

- Add a "wrapped channel" client transport which takes ownership of a NIO channel and configures the channels pipeline to do gRPC.
- This is a different transport because a number of features aren't available such as reconnects and client-side load-balancing.

Result:

Users can wrap an existing NIO channel into a custom transport.