### PR TITLE
Add API for custom private keys

### DIFF
--- a/Sources/GRPCNIOTransportCore/TLSConfig+Internal.swift
+++ b/Sources/GRPCNIOTransportCore/TLSConfig+Internal.swift
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extension TLSConfig.PrivateKeySource {
+  /// Marker protocol for transport specific private key sources.
+  ///
+  /// `TLSConfig.PrivateKeySource` is from the core module which means it can't take a NIOSSL
+  /// or NIOTransportServices dependency. In order to support more sources this transport-specific
+  /// protocol is provided as non-public API.
+  package protocol TransportSpecific: Sendable {}
+
+  package static func transportSpecific(_ source: any TransportSpecific) -> Self {
+    Self(wrapped: .transportSpecific(source))
+  }
+}

--- a/Sources/GRPCNIOTransportCore/TLSConfig.swift
+++ b/Sources/GRPCNIOTransportCore/TLSConfig.swift
@@ -63,6 +63,7 @@ public enum TLSConfig: Sendable {
     package enum Wrapped {
       case file(path: String, format: SerializationFormat)
       case bytes(bytes: [UInt8], format: SerializationFormat)
+      case transportSpecific(any TransportSpecific)
     }
 
     package let wrapped: Wrapped

--- a/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+public import NIOSSL
+
 extension HTTP2ServerTransport.Posix {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -306,5 +308,18 @@ extension HTTP2ClientTransport.Posix.TransportSecurity {
       configure(&config)
       return config
     }
+  }
+}
+
+extension TLSConfig.PrivateKeySource {
+  /// Creates a key source from a `NIOSSLCustomPrivateKey`.
+  ///
+  /// This private key source is only applicable to the NIOPosix based transports. Using one
+  /// with a NIOTransportServices based transport is a programmer error.
+  ///
+  /// - Parameter key: The custom private key.
+  /// - Returns: A private key source wrapping the custom private key.
+  public static func customPrivateKey(_ key: any (NIOSSLCustomPrivateKey & Hashable)) -> Self {
+    .nioSSLSpecific(.customPrivateKey(key))
   }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/TLSConfigurationTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/TLSConfigurationTests.swift
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCNIOTransportHTTP2
+import NIOCore
+import NIOSSL
+import Testing
+
+struct TLSConfigurationTests {
+  struct NoOpCustomPrivateKey: NIOSSLCustomPrivateKey, Hashable {
+    var signatureAlgorithms: [SignatureAlgorithm] { [] }
+
+    func sign(
+      channel: any Channel,
+      algorithm: SignatureAlgorithm,
+      data: ByteBuffer
+    ) -> EventLoopFuture<ByteBuffer> {
+      channel.eventLoop.makeSucceededFuture(ByteBuffer())
+    }
+
+    func decrypt(channel: any Channel, data: ByteBuffer) -> EventLoopFuture<ByteBuffer> {
+      channel.eventLoop.makeSucceededFuture(ByteBuffer())
+    }
+  }
+
+  @Test("Client custom private key")
+  func clientTLSCustomPrivateKey() throws {
+    let custom = NoOpCustomPrivateKey()
+    let config = HTTP2ClientTransport.Posix.TransportSecurity.tls {
+      $0.privateKey = .customPrivateKey(custom)
+    }
+
+    let tls = try #require(config.tls)
+    let tlsConfig = try TLSConfiguration(tls)
+    let privateKey = try #require(tlsConfig.privateKey?.privateKey)
+    #expect(privateKey == NIOSSLPrivateKey(customPrivateKey: custom))
+  }
+
+  @Test("Server custom private key")
+  func serverTLSCustomPrivateKey() throws {
+    let custom = NoOpCustomPrivateKey()
+    let config = HTTP2ServerTransport.Posix.TransportSecurity.tls(
+      certificateChain: [],
+      privateKey: .customPrivateKey(custom)
+    )
+
+    let tls = try #require(config.tls)
+    let tlsConfig = try TLSConfiguration(tls)
+    let privateKey = try #require(tlsConfig.privateKey?.privateKey)
+    #expect(privateKey == NIOSSLPrivateKey(customPrivateKey: custom))
+  }
+}
+
+extension HTTP2ClientTransport.Posix.TransportSecurity {
+  var tls: TLS? {
+    switch self.wrapped {
+    case .tls(let tls):
+      return tls
+    case .plaintext:
+      return nil
+    }
+  }
+}
+
+extension HTTP2ServerTransport.Posix.TransportSecurity {
+  var tls: TLS? {
+    switch self.wrapped {
+    case .tls(let tls):
+      return tls
+    case .plaintext:
+      return nil
+    }
+  }
+}
+
+extension NIOSSLPrivateKeySource {
+  var privateKey: NIOSSLPrivateKey? {
+    switch self {
+    case .privateKey(let key):
+      return key
+    case .file:
+      return nil
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

NIOSSL has support for custom private keys which may be comre from some form of high-security storage. This API isn't currently available to users.

Modifications:

- Extend private key source with a transport specific backing and add API to initialize it with a custom private key

Result:

NIOSSLs custom private keys can be used.