### PR TITLE
Move availability inline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
 
   construct-integration-tests-matrix:
     name: Construct integration matrix

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
 
   construct-integration-tests-matrix:
     name: Construct integration matrix

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    from: "2.2.0"
+    from: "2.2.1"
   ),
   .package(
     url: "https://github.com/apple/swift-nio.git",
@@ -67,12 +67,28 @@ let dependencies: [Package.Dependency] = [
   ),
 ]
 
-let defaultSwiftSettings: [SwiftSetting] = [
-  .swiftLanguageMode(.v6),
-  .enableUpcomingFeature("ExistentialAny"),
-  .enableUpcomingFeature("InternalImportsByDefault"),
-  .enableUpcomingFeature("MemberImportVisibility"),
-]
+// -------------------------------------------------------------------------------------------------
+
+// This adds some build settings which allow us to map "@available(gRPCSwiftNIOTransport 1.x, *)" to
+// the appropriate OS platforms.
+let nextMinorVersion = 3
+let availabilitySettings: [SwiftSetting] = (0 ... nextMinorVersion).map { minor in
+  let name = "gRPCSwiftNIOTransport"
+  let version = "1.\(minor)"
+  let platforms = "macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
+  let setting = "AvailabilityMacro=\(name) \(version):\(platforms)"
+  return .enableExperimentalFeature(setting)
+}
+
+let defaultSwiftSettings: [SwiftSetting] =
+  availabilitySettings + [
+    .swiftLanguageMode(.v6),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+  ]
+
+// -------------------------------------------------------------------------------------------------
 
 let targets: [Target] = [
   // C-module for z-lib shims
@@ -156,13 +172,6 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift-nio-transport",
-  platforms: [
-    .macOS(.v15),
-    .iOS(.v18),
-    .tvOS(.v18),
-    .watchOS(.v11),
-    .visionOS(.v2),
-  ],
   products: products,
   dependencies: dependencies,
   targets: targets

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -43,6 +43,7 @@ private import Synchronization
 ///   }
 /// }
 /// ```
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class Connection: Sendable {
   /// Events which can happen over the lifetime of the connection.
   package enum Event: Sendable {
@@ -405,6 +406,7 @@ package final class Connection: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection {
   package struct Stream {
     package typealias Inbound = NIOAsyncChannelInboundStream<RPCResponsePart<GRPCNIOTransportBytes>>
@@ -478,6 +480,7 @@ extension Connection {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection {
   private enum State: Sendable {
     /// The connection is idle or connecting.

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionBackoff.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionBackoff.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package struct ConnectionBackoff {
   package var initial: Duration
   package var max: Duration

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectionFactory.swift
@@ -18,6 +18,7 @@ package import NIOCore
 package import NIOHTTP2
 internal import NIOPosix
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package protocol HTTP2Connector: Sendable {
   /// Attempt to establish a connection to the given address.
   ///
@@ -30,6 +31,7 @@ package protocol HTTP2Connector: Sendable {
   ) async throws -> HTTP2Connection
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package struct HTTP2Connection: Sendable {
   /// The underlying TCP connection wrapped up for use with gRPC.
   var channel: NIOAsyncChannel<ClientConnectionEvent, Void>

--- a/Sources/GRPCNIOTransportCore/Client/Connection/ConnectivityState.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/ConnectivityState.swift
@@ -16,6 +16,7 @@
 
 package import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package enum ConnectivityState: Sendable, Hashable {
   /// This channel isn't trying to create a connection because of a lack of new or pending RPCs.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -18,6 +18,7 @@ private import DequeModule
 package import GRPCCore
 private import Synchronization
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class GRPCChannel: ClientTransport {
   package typealias Bytes = GRPCNIOTransportBytes
 
@@ -239,6 +240,7 @@ package final class GRPCChannel: ClientTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel {
   package struct Config: Sendable {
     /// Configuration for HTTP/2 connections.
@@ -267,6 +269,7 @@ extension GRPCChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel {
   enum MakeStreamResult {
     /// A stream was created, use it.
@@ -365,6 +368,7 @@ extension GRPCChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel {
   private func handleClose(in group: inout DiscardingTaskGroup) {
     switch self.state.withLock({ $0.close() }) {
@@ -593,6 +597,7 @@ extension GRPCChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel {
   struct StateMachine {
     enum State {
@@ -667,6 +672,7 @@ extension GRPCChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel.StateMachine {
   mutating func start() {
     precondition(!self.running, "channel must only be started once")

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancer.swift
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package enum LoadBalancer: Sendable {
   case roundRobin(RoundRobinLoadBalancer)
   case pickFirst(PickFirstLoadBalancer)
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension LoadBalancer {
   package init(_ loadBalancer: RoundRobinLoadBalancer) {
     self = .roundRobin(loadBalancer)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancerEvent.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/LoadBalancerEvent.swift
@@ -15,6 +15,7 @@
  */
 
 /// Events emitted by load-balancers.
+@available(gRPCSwiftNIOTransport 1.0, *)
 package enum LoadBalancerEvent: Sendable, Hashable {
   /// The connectivity state of the subchannel changed.
   case connectivityStateChanged(ConnectivityState)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -56,6 +56,7 @@ private import Synchronization
 ///   }
 /// }
 /// ```
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class PickFirstLoadBalancer: Sendable {
   enum Input: Sendable, Hashable {
     /// Update the addresses used by the load balancer to the following endpoints.
@@ -170,6 +171,7 @@ package final class PickFirstLoadBalancer: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer {
   private func handleUpdateEndpoint(_ endpoint: Endpoint, in group: inout DiscardingTaskGroup) {
     if endpoint.addresses.isEmpty { return }
@@ -271,6 +273,7 @@ extension PickFirstLoadBalancer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer {
   enum State: Sendable {
     case active(Active)
@@ -283,6 +286,7 @@ extension PickFirstLoadBalancer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer.State {
   struct Active: Sendable {
     var endpoint: Endpoint?
@@ -311,6 +315,7 @@ extension PickFirstLoadBalancer.State {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer.State.Active {
   mutating func updateEndpoint(
     _ endpoint: Endpoint,
@@ -480,6 +485,7 @@ extension PickFirstLoadBalancer.State.Active {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer.State.Closing {
   mutating func updateSubchannelConnectivityState(
     _ connectivityState: ConnectivityState,
@@ -520,6 +526,7 @@ extension PickFirstLoadBalancer.State.Closing {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension PickFirstLoadBalancer.State {
   enum OnUpdateEndpoint {
     case connect(Subchannel, close: Subchannel?)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -58,6 +58,7 @@ private import NIOConcurrencyHelpers
 ///   }
 /// }
 /// ```
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class RoundRobinLoadBalancer: Sendable {
   enum Input: Sendable, Hashable {
     /// Update the addresses used by the load balancer to the following endpoints.
@@ -203,6 +204,7 @@ package final class RoundRobinLoadBalancer: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension RoundRobinLoadBalancer {
   /// Handles an update in endpoints.
   ///
@@ -345,6 +347,7 @@ extension RoundRobinLoadBalancer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension RoundRobinLoadBalancer {
   private enum State {
     case active(Active)
@@ -738,6 +741,7 @@ extension RoundRobinLoadBalancer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ConnectivityState {
   static func aggregate(_ states: some Collection<ConnectivityState>) -> ConnectivityState {
     // See https://github.com/grpc/grpc/blob/7f664c69b2a636386fbf95c16bc78c559734ce0f/doc/load-balancing.md

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -43,6 +43,7 @@ private import Synchronization
 ///   }
 /// }
 /// ```
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class Subchannel: Sendable {
   package enum Event: Sendable, Hashable {
     /// The connection received a GOAWAY and will close soon. No new streams
@@ -122,6 +123,7 @@ package final class Subchannel: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Subchannel {
   /// A stream of events which can happen to the subchannel.
   package var events: AsyncStream<Event> {
@@ -194,6 +196,7 @@ extension Subchannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Subchannel {
   private func handleConnectInput(in group: inout DiscardingTaskGroup) {
     let connection = self.state.withLock { state in
@@ -379,6 +382,7 @@ extension Subchannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Subchannel {
   /// ```
   ///            ┌───────────────┐

--- a/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/RequestQueue.swift
@@ -16,6 +16,7 @@
 
 internal import DequeModule
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct RequestQueue<Element> {
   typealias Continuation = CheckedContinuation<Element, any Error>
 

--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -18,6 +18,7 @@ internal import GRPCCore
 internal import NIOCore
 internal import NIOHTTP2
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCClientStreamHandler: ChannelDuplexHandler {
   typealias InboundIn = HTTP2Frame.FramePayload
   typealias InboundOut = RPCResponsePart<GRPCNIOTransportBytes>
@@ -58,6 +59,7 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
 
 // - MARK: ChannelInboundHandler
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCClientStreamHandler {
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     self.isReading = true
@@ -178,6 +180,7 @@ extension GRPCClientStreamHandler {
 
 // - MARK: ChannelOutboundHandler
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCClientStreamHandler {
   func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
     switch self.unwrapOutboundIn(data) {

--- a/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
@@ -18,13 +18,16 @@ public import GRPCCore
 public import NIOCore
 
 /// A namespace for the HTTP/2 client transport.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public enum HTTP2ClientTransport {}
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport {
   /// A namespace for HTTP/2 client transport configuration.
   public enum Config {}
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.Config {
   public struct Compression: Sendable, Hashable {
     /// The default algorithm used for compressing outbound messages.

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
@@ -27,6 +27,7 @@ private import Musl
 #endif
 
 /// An asynchronous non-blocking DNS resolver built on top of the libc `getaddrinfo` function.
+@available(gRPCSwiftNIOTransport 1.0, *)
 package enum DNSResolver {
   private static let dispatchQueue = DispatchQueue(
     label: "io.grpc.DNSResolver"
@@ -133,6 +134,7 @@ package enum DNSResolver {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension DNSResolver {
   /// `Error` that may be thrown based on the error code returned by `getaddrinfo`.
   package struct GetAddrInfoError: Error, Hashable, CustomStringConvertible {
@@ -148,6 +150,7 @@ extension DNSResolver {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension DNSResolver {
   /// `Error` that may be thrown based on the system error encountered by `inet_ntop`.
   package struct InetNetworkToPresentationError: Error, Hashable {
@@ -159,6 +162,7 @@ extension DNSResolver {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.IPv4 {
   fileprivate init(_ address: sockaddr_in) throws {
     let presentationAddress = try withUnsafePointer(to: address.sin_addr) { addressPtr in
@@ -173,6 +177,7 @@ extension SocketAddress.IPv4 {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.IPv6 {
   fileprivate init(_ address: sockaddr_in6) throws {
     let presentationAddress = try withUnsafePointer(to: address.sin6_addr) { addressPtr in

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+DNS.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+DNS.swift
@@ -16,6 +16,7 @@
 
 private import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTargets {
   /// A resolvable target for addresses which can be resolved via DNS.
   ///
@@ -41,6 +42,7 @@ extension ResolvableTargets {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTarget where Self == ResolvableTargets.DNS {
   /// Creates a new resolvable DNS target.
   /// - Parameters:
@@ -52,6 +54,7 @@ extension ResolvableTarget where Self == ResolvableTargets.DNS {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/DNS`` targets.
   public struct DNS: NameResolverFactory {
@@ -74,6 +77,7 @@ extension NameResolvers {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers.DNS {
   struct Resolver: Sendable {
     var target: ResolvableTargets.DNS
@@ -107,6 +111,7 @@ extension NameResolvers.DNS {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers.DNS.Resolver: AsyncSequence {
   typealias Element = NameResolutionResult
 

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv4.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv4.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTargets {
   /// A resolvable target for IPv4 addresses.
   ///
@@ -33,6 +34,7 @@ extension ResolvableTargets {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTarget where Self == ResolvableTargets.IPv4 {
   /// Creates a new resolvable IPv4 target for a single address.
   /// - Parameters:
@@ -54,6 +56,7 @@ extension ResolvableTarget where Self == ResolvableTargets.IPv4 {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/IPv4`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv6.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+IPv6.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTargets {
   /// A resolvable target for IPv4 addresses.
   ///
@@ -33,6 +34,7 @@ extension ResolvableTargets {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTarget where Self == ResolvableTargets.IPv6 {
   /// Creates a new resolvable IPv6 target for a single address.
   /// - Parameters:
@@ -54,6 +56,7 @@ extension ResolvableTarget where Self == ResolvableTargets.IPv6 {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/IPv6`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+UDS.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTargets {
   /// A resolvable target for Unix Domain Socket address.
   ///
@@ -38,6 +39,7 @@ extension ResolvableTargets {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTarget where Self == ResolvableTargets.UnixDomainSocket {
   /// Creates a new resolvable Unix Domain Socket target.
   /// - Parameters
@@ -54,6 +56,7 @@ extension ResolvableTarget where Self == ResolvableTargets.UnixDomainSocket {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/UnixDomainSocket`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+VSOCK.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver+VSOCK.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTargets {
   /// A resolvable target for Virtual Socket addresses.
   ///
@@ -30,6 +31,7 @@ extension ResolvableTargets {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ResolvableTarget where Self == ResolvableTargets.VirtualSocket {
   /// Creates a new resolvable Virtual Socket target.
   /// - Parameters:
@@ -44,6 +46,7 @@ extension ResolvableTarget where Self == ResolvableTargets.VirtualSocket {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolvers {
   /// A ``NameResolverFactory`` for ``ResolvableTargets/VirtualSocket`` targets.
   ///

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolver.swift
@@ -17,6 +17,7 @@
 public import GRPCCore
 
 /// A name resolver can provide resolved addresses and service configuration values over time.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct NameResolver: Sendable {
   /// A sequence of name resolution results.
   ///
@@ -67,6 +68,7 @@ public struct NameResolver: Sendable {
 
 /// The result of name resolution, a list of endpoints to connect to and the service
 /// configuration reported by the resolver.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct NameResolutionResult: Hashable, Sendable {
   /// A list of endpoints to connect to.
   public var endpoints: [Endpoint]
@@ -85,6 +87,7 @@ public struct NameResolutionResult: Hashable, Sendable {
 }
 
 /// A group of addresses which are considered equivalent when establishing a connection.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct Endpoint: Hashable, Sendable {
   /// A list of equivalent addresses.
   ///
@@ -100,6 +103,7 @@ public struct Endpoint: Hashable, Sendable {
 }
 
 /// A resolver capable of resolving targets of type ``Target``.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public protocol NameResolverFactory<Target> {
   /// The type of ``ResolvableTarget`` this factory makes resolvers for.
   associatedtype Target: ResolvableTarget
@@ -111,6 +115,7 @@ public protocol NameResolverFactory<Target> {
   func resolver(for target: Target) -> NameResolver
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolverFactory {
   /// Returns whether the given target is compatible with this factory.
   ///
@@ -131,10 +136,13 @@ extension NameResolverFactory {
 }
 
 /// A target which can be resolved to a ``SocketAddress``.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public protocol ResolvableTarget {}
 
 /// A namespace for resolvable targets.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public enum ResolvableTargets {}
 
 /// A namespace for name resolver factories.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public enum NameResolvers {}

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolverRegistry.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/NameResolverRegistry.swift
@@ -37,6 +37,7 @@
 ///   // ...
 /// }
 /// ```
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct NameResolverRegistry {
   private enum Factory {
     case dns(NameResolvers.DNS)

--- a/Sources/GRPCNIOTransportCore/Client/Resolver/SocketAddress.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/SocketAddress.swift
@@ -15,6 +15,7 @@
  */
 
 /// An address to which a socket may connect or bind.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct SocketAddress: Hashable, Sendable {
   private enum Value: Hashable, Sendable {
     case ipv4(IPv4)
@@ -69,6 +70,7 @@ public struct SocketAddress: Hashable, Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress {
   package var authority: String {
     let rawValue: String
@@ -98,6 +100,7 @@ extension SocketAddress {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress {
   /// Creates a socket address by wrapping a ``SocketAddress/IPv4-swift.struct``.
   public static func ipv4(_ address: IPv4) -> Self {
@@ -120,6 +123,7 @@ extension SocketAddress {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress {
   /// Creates an IPv4 socket address.
   public static func ipv4(host: String, port: Int) -> Self {
@@ -141,6 +145,7 @@ extension SocketAddress {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress: CustomStringConvertible {
   public var description: String {
     switch self.value {
@@ -156,6 +161,7 @@ extension SocketAddress: CustomStringConvertible {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress {
   public struct IPv4: Hashable, Sendable {
     /// The resolved host address.
@@ -305,36 +311,42 @@ extension SocketAddress {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.IPv4: CustomStringConvertible {
   public var description: String {
     "[ipv4]\(self.host):\(self.port)"
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.IPv6: CustomStringConvertible {
   public var description: String {
     "[ipv6]\(self.host):\(self.port)"
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.UnixDomainSocket: CustomStringConvertible {
   public var description: String {
     "[unix]\(self.path)"
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.VirtualSocket: CustomStringConvertible {
   public var description: String {
     "[vsock]\(self.contextID):\(self.port)"
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.VirtualSocket.ContextID: CustomStringConvertible {
   public var description: String {
     self == .any ? "-1" : String(describing: self.rawValue)
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension SocketAddress.VirtualSocket.Port: CustomStringConvertible {
   public var description: String {
     self == .any ? "-1" : String(describing: self.rawValue)

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+Config.swift
@@ -16,6 +16,7 @@
 
 public import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ClientTransport.WrappedChannel {
   public struct Config: Sendable {
     /// Configuration for HTTP/2 connections.
@@ -73,6 +74,7 @@ extension HTTP2ClientTransport.WrappedChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ClientTransport.WrappedChannel.Config {
   /// Callbacks used for debugging purposes.
   ///
@@ -98,6 +100,7 @@ extension HTTP2ClientTransport.WrappedChannel.Config {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension GRPCChannel.Config {
   init(_ config: HTTP2ClientTransport.WrappedChannel.Config) {
     self.init(

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+State.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel+State.swift
@@ -17,6 +17,7 @@
 internal import GRPCCore
 internal import NIOHTTP2
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ClientTransport.WrappedChannel {
   enum State: ~Copyable {
     case idle(Idle)
@@ -69,6 +70,7 @@ extension HTTP2ClientTransport.WrappedChannel {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ClientTransport.WrappedChannel.State {
   enum ConnectAction {
     case configureChannel

--- a/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/WrappedChannel/WrappedChannel.swift
@@ -41,7 +41,9 @@ private import Synchronization
 /// By providing a channel to this transport you hand ownership of it to the transport. The
 /// transport therefore becomes responsible for closing the channel at the appropriate point
 /// in time.
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport {
+  @available(gRPCSwiftNIOTransport 1.2, *)
   public final class WrappedChannel: ClientTransport {
     public typealias Bytes = GRPCNIOTransportBytes
 
@@ -285,6 +287,7 @@ extension HTTP2ClientTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension ClientTransport where Self == HTTP2ClientTransport.WrappedChannel {
   /// Create a new wrapping client transport from an already connection NIO `Channel`.
   ///

--- a/Sources/GRPCNIOTransportCore/Compression/CompressionAlgorithm.swift
+++ b/Sources/GRPCNIOTransportCore/Compression/CompressionAlgorithm.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension CompressionAlgorithm {
   init?(name: String) {
     self.init(name: name[...])
@@ -48,6 +49,7 @@ extension CompressionAlgorithm {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension CompressionAlgorithmSet {
   var count: Int {
     self.rawValue.nonzeroBitCount

--- a/Sources/GRPCNIOTransportCore/Compression/Zlib.swift
+++ b/Sources/GRPCNIOTransportCore/Compression/Zlib.swift
@@ -18,6 +18,7 @@ internal import CGRPCNIOTransportZlib
 internal import GRPCCore
 internal import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum Zlib {
   enum Method {
     case deflate
@@ -34,6 +35,7 @@ enum Zlib {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Zlib {
   /// Creates a new compressor for the given compression format.
   ///
@@ -85,6 +87,7 @@ extension Zlib {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Zlib {
   /// Creates a new decompressor for the given compression format.
   ///
@@ -146,6 +149,7 @@ struct ZlibError: Error, Hashable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension UnsafeMutablePointer<z_stream> {
   func inflateInit(windowBits: Int32) {
     self.pointee.zfree = nil

--- a/Sources/GRPCNIOTransportCore/GRPCMessageDecoder.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCMessageDecoder.swift
@@ -21,6 +21,7 @@ package import NIOCore
 /// - It reads the frame's metadata to know whether the message payload is compressed or not, and its length
 /// - It reads and decompresses the payload, if compressed
 /// - It helps put together frames that have been split across multiple `ByteBuffers` by the underlying transport
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct GRPCMessageDecoder: NIOSingleStepByteToMessageDecoder {
   /// Length of the gRPC message header (1 compression byte, 4 bytes for the length).
   static let metadataLength = 5
@@ -101,6 +102,7 @@ struct GRPCMessageDecoder: NIOSingleStepByteToMessageDecoder {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package struct GRPCMessageDeframer {
   private var decoder: GRPCMessageDecoder
   private var buffer: Optional<ByteBuffer>
@@ -144,6 +146,7 @@ package struct GRPCMessageDeframer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCMessageDeframer {
   mutating func decode(into queue: inout OneOrManyQueue<ByteBuffer>) throws {
     while let next = try self.decodeNext() {

--- a/Sources/GRPCNIOTransportCore/GRPCMessageFramer.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCMessageFramer.swift
@@ -22,6 +22,7 @@ internal import NIOCore
 /// - It compresses messages using the specified compression algorithm (if configured).
 /// - It coalesces multiple messages (appended into the `Framer` by calling ``append(_:compress:)``)
 /// into a single `ByteBuffer`.
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct GRPCMessageFramer {
   /// Length of the gRPC message header (1 compression byte, 4 bytes for the length).
   static let metadataLength = 5

--- a/Sources/GRPCNIOTransportCore/GRPCNIOTransportBytes.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCNIOTransportBytes.swift
@@ -18,6 +18,7 @@ public import GRPCCore
 public import NIOCore
 
 /// The contiguous bytes type used by the gRPC's NIO transport.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public struct GRPCNIOTransportBytes: GRPCContiguousBytes, Hashable, Sendable {
   @usableFromInline
   internal var buffer: ByteBuffer

--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -24,6 +24,7 @@ package enum Scheme: String {
   case https
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum GRPCStreamStateMachineConfiguration {
   case client(ClientConfiguration)
   case server(ServerConfiguration)
@@ -61,6 +62,7 @@ enum GRPCStreamStateMachineConfiguration {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 private enum GRPCStreamStateMachineState {
   case clientIdleServerIdle(ClientIdleServerIdleState)
   case clientOpenServerIdle(ClientOpenServerIdleState)
@@ -393,6 +395,7 @@ private enum GRPCStreamStateMachineState {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct GRPCStreamStateMachine {
   private var state: GRPCStreamStateMachineState
   private var configuration: GRPCStreamStateMachineConfiguration
@@ -629,6 +632,7 @@ struct GRPCStreamStateMachine {
 
 // - MARK: Client
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCStreamStateMachine {
   private func makeClientHeaders(
     methodDescriptor: MethodDescriptor,
@@ -1238,6 +1242,7 @@ extension GRPCStreamStateMachine {
 
 // - MARK: Server
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCStreamStateMachine {
   private func formResponseHeaders(
     in headers: inout HPACKHeaders,
@@ -1759,6 +1764,7 @@ extension GRPCStreamStateMachine {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodDescriptor {
   init?(path: String) {
     var view = path[...]
@@ -1789,6 +1795,7 @@ internal enum GRPCHTTP2Keys: String {
   case grpcStatusMessage = "grpc-message"
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HPACKHeaders {
   func firstString(forKey key: GRPCHTTP2Keys, canonicalForm: Bool = true) -> String? {
     self.values(forHeader: key.rawValue, canonicalForm: canonicalForm).first(where: { _ in true })
@@ -1848,6 +1855,7 @@ extension HPACKHeaders {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Zlib.Method {
   init?(encoding: CompressionAlgorithm) {
     switch encoding {
@@ -1863,6 +1871,7 @@ extension Zlib.Method {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Metadata {
   init(headers: HPACKHeaders) {
     var metadata = Metadata()
@@ -1883,6 +1892,7 @@ extension Metadata {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Status.Code {
   // See https://github.com/grpc/grpc/blob/7f664c69b2a636386fbf95c16bc78c559734ce0f/doc/http-grpc-status-mapping.md
   init(httpStatusCode: HTTPResponseStatus) {
@@ -1903,12 +1913,14 @@ extension Status.Code {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodDescriptor {
   var path: String {
     return "/\(self.service)/\(self.method)"
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension RPCError {
   fileprivate init(_ reason: GRPCStreamStateMachine.UnexpectedInboundCloseReason) {
     switch reason {
@@ -1925,12 +1937,14 @@ extension RPCError {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Status {
   fileprivate init(_ error: RPCError) {
     self = Status(code: Status.Code(error.code), message: error.message)
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension RPCError {
   init(_ invalidState: GRPCStreamStateMachine.InvalidState) {
     self = RPCError(code: .internalError, message: "Invalid state", cause: invalidState)

--- a/Sources/GRPCNIOTransportCore/Internal/CallOptions+MethodConfig.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/CallOptions+MethodConfig.swift
@@ -16,6 +16,7 @@
 
 package import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension CallOptions {
   package mutating func formUnion(with methodConfig: MethodConfig?) {
     guard let methodConfig = methodConfig else { return }

--- a/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Channel+AddressInfo.swift
@@ -16,6 +16,7 @@
 
 internal import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Channel {
   var remoteAddressInfo: String {
     self.getAddressInfoWithFallbackIfUDS(

--- a/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
@@ -40,6 +40,7 @@ private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension RPCAsyncSequence where Element: Sendable, Failure == any Error {
   static func constant(_ element: Element) -> RPCAsyncSequence<Element, any Error> {
     return RPCAsyncSequence(wrapping: ConstantAsyncSequence(element: element))

--- a/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension DiscardingTaskGroup {
   /// Adds a child task to the group which is individually cancellable.
   ///
@@ -61,6 +62,7 @@ extension DiscardingTaskGroup {
 }
 
 @usableFromInline
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct CancellableTaskHandle: Sendable {
   @usableFromInline
   private(set) var continuation: AsyncStream<Void>.Continuation

--- a/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/MethodConfigs.swift
@@ -24,6 +24,7 @@ package import GRPCCore
 /// service, or set a default configuration for all methods by calling ``setDefaultConfig(_:)``.
 ///
 /// Use the subscript to get and set configurations for specific methods.
+@available(gRPCSwiftNIOTransport 1.0, *)
 package struct MethodConfigs: Sendable, Hashable {
   private var elements: [MethodConfig.Name: MethodConfig]
 

--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -19,6 +19,7 @@ package import NIOCore
 internal import NIOHPACK
 package import NIOHTTP2
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ChannelPipeline.SynchronousOperations {
   package typealias HTTP2ConnectionChannel = NIOAsyncChannel<HTTP2Frame, HTTP2Frame>
   package typealias HTTP2StreamMultiplexer = NIOHTTP2Handler.AsyncStreamMultiplexer<
@@ -123,6 +124,7 @@ extension ChannelPipeline.SynchronousOperations {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ChannelPipeline.SynchronousOperations {
   package func configureGRPCClientPipeline(
     channel: any Channel,

--- a/Sources/GRPCNIOTransportCore/Internal/NIOSocketAddress+GRPCSocketAddress.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOSocketAddress+GRPCSocketAddress.swift
@@ -17,6 +17,7 @@
 private import GRPCCore
 package import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCNIOTransportCore.SocketAddress {
   package init(_ nioSocketAddress: NIOCore.SocketAddress) {
     switch nioSocketAddress {
@@ -38,6 +39,7 @@ extension GRPCNIOTransportCore.SocketAddress {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOCore.SocketAddress {
   package init(_ socketAddress: SocketAddress) throws {
     if let ipv4 = socketAddress.ipv4 {

--- a/Sources/GRPCNIOTransportCore/Internal/ProcessUniqueID.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/ProcessUniqueID.swift
@@ -17,6 +17,7 @@
 private import Synchronization
 
 /// An ID which is unique within this process.
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
   private static let source = Atomic(UInt64(0))
   private let rawValue: UInt64
@@ -32,6 +33,7 @@ struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a subchannel.
+@available(gRPCSwiftNIOTransport 1.0, *)
 package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   package init() {}
@@ -41,6 +43,7 @@ package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a load-balancer.
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {
@@ -49,6 +52,7 @@ struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for an entry in a queue.
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct QueueEntryID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {

--- a/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/Result+Catching.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Result {
   /// Like `Result(catching:)`, but `async`.
   ///

--- a/Sources/GRPCNIOTransportCore/ListeningServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/ListeningServerTransport.swift
@@ -18,11 +18,13 @@ public import GRPCCore
 
 /// A transport which refines `ServerTransport` to provide the socket address of a listening
 /// server.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public protocol ListeningServerTransport: ServerTransport {
   /// Returns the listening address of the server transport once it has started.
   var listeningAddress: SocketAddress { get async throws }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCServer {
   /// Returns the listening address of the server transport once it has started.
   ///

--- a/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/CommonHTTP2ServerTransport.swift
@@ -23,6 +23,7 @@ private import Synchronization
 /// Provides the common functionality for a `NIO`-based server transport.
 ///
 /// - SeeAlso: ``HTTP2ListenerFactory``.
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class CommonHTTP2ServerTransport<
   ListenerFactory: HTTP2ListenerFactory
 >: ServerTransport, ListeningServerTransport {

--- a/Sources/GRPCNIOTransportCore/Server/Connection/GRPCServerFlushNotificationHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/GRPCServerFlushNotificationHandler.swift
@@ -16,6 +16,7 @@
 
 internal import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCServerFlushNotificationHandler: ChannelOutboundHandler {
   typealias OutboundIn = Any
   typealias OutboundOut = Any

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnection.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnection.swift
@@ -17,6 +17,7 @@
 package import GRPCCore
 package import NIOCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package enum ServerConnection {
   package enum Stream {
     package struct Outbound: ClosableRPCWriterProtocol {

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
@@ -17,6 +17,7 @@
 internal import NIOCore
 internal import NIOHTTP2
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler {
   /// Tracks the state of TCP connections at the server.
   ///
@@ -283,6 +284,7 @@ extension ServerConnectionManagementHandler {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler.StateMachine {
   fileprivate struct Keepalive {
     /// Allow the client to send keep alive pings when there are no active calls.
@@ -354,6 +356,7 @@ extension ServerConnectionManagementHandler.StateMachine {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler.StateMachine {
   fileprivate enum State {
     /// The connection is active.

--- a/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/Connection/ServerConnectionManagementHandler.swift
@@ -39,6 +39,7 @@ private import NIOTLS
 /// Some of the behaviours are described in:
 /// - [gRFC A8](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A8-client-side-keepalive.md), and
 /// - [gRFC A9](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A9-server-side-conn-mgt.md).
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
   package typealias InboundIn = HTTP2Frame
   package typealias InboundOut = HTTP2Frame
@@ -416,6 +417,7 @@ package final class ServerConnectionManagementHandler: ChannelDuplexHandler {
 }
 
 // Timer handler views.
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler {
   struct MaxIdleTimerHandlerView: @unchecked Sendable, NIOScheduledCallbackHandler {
     private let handler: ServerConnectionManagementHandler
@@ -483,6 +485,7 @@ extension ServerConnectionManagementHandler {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler {
   package struct HTTP2StreamDelegate: @unchecked Sendable, NIOHTTP2StreamDelegate {
     // @unchecked is okay: the only methods do the appropriate event-loop dance.
@@ -555,6 +558,7 @@ extension ServerConnectionManagementHandler {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandler {
   private func maybeFlush(context: ChannelHandlerContext) {
     if self.inReadLoop {

--- a/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
@@ -18,6 +18,7 @@ package import GRPCCore
 package import NIOCore
 package import NIOHTTP2
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChannelHandler {
   package typealias InboundIn = HTTP2Frame.FramePayload
   package typealias InboundOut = RPCRequestPart<GRPCNIOTransportBytes>
@@ -104,6 +105,7 @@ package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChan
 
 // - MARK: ChannelInboundHandler
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCServerStreamHandler {
   package func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
     switch event {
@@ -256,6 +258,7 @@ extension GRPCServerStreamHandler {
 
 // - MARK: ChannelOutboundHandler
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCServerStreamHandler {
   package func write(
     context: ChannelHandlerContext,

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ListenerFactory.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ListenerFactory.swift
@@ -20,6 +20,7 @@ package import NIOExtras
 /// A factory to produce `NIOAsyncChannel`s to listen for new HTTP/2 connections.
 ///
 /// - SeeAlso: ``CommonHTTP2ServerTransport``
+@available(gRPCSwiftNIOTransport 1.0, *)
 package protocol HTTP2ListenerFactory: Sendable {
   typealias AcceptedChannel = (
     ChannelPipeline.SynchronousOperations.HTTP2ConnectionChannel,

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
@@ -19,13 +19,16 @@ public import NIOCore
 internal import NIOHTTP2
 
 /// A namespace for the HTTP/2 server transport.
+@available(gRPCSwiftNIOTransport 1.0, *)
 public enum HTTP2ServerTransport {}
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport {
   /// A namespace for HTTP/2 server transport configuration.
   public enum Config {}
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.Config {
   public struct Compression: Sendable, Hashable {
     /// Compression algorithms enabled for inbound messages.

--- a/Sources/GRPCNIOTransportCore/TLSConfig+Internal.swift
+++ b/Sources/GRPCNIOTransportCore/TLSConfig+Internal.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension TLSConfig.PrivateKeySource {
   /// Marker protocol for transport specific private key sources.
   ///
@@ -27,6 +28,7 @@ extension TLSConfig.PrivateKeySource {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension TLSConfig.CertificateSource {
   /// A type-erased transport specific certificate source.
   ///

--- a/Sources/GRPCNIOTransportCore/TLSConfig.swift
+++ b/Sources/GRPCNIOTransportCore/TLSConfig.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 public enum TLSConfig: Sendable {
   /// The serialization format of the provided certificates and private keys.
   public struct SerializationFormat: Sendable, Equatable {

--- a/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/Config+TLS.swift
@@ -18,6 +18,7 @@ private import GRPCCore
 public import NIOCertificateReloading
 public import NIOSSL
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.Posix {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -142,6 +143,7 @@ extension HTTP2ServerTransport.Posix {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.Posix.TransportSecurity {
   public struct TLS: Sendable {
     /// The certificates the server will offer during negotiation.
@@ -241,6 +243,7 @@ extension HTTP2ServerTransport.Posix.TransportSecurity {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.Posix {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -327,6 +330,7 @@ extension HTTP2ClientTransport.Posix {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.Posix.TransportSecurity {
   public struct TLS: Sendable {
     /// The certificates the client will offer during negotiation.
@@ -419,6 +423,7 @@ extension HTTP2ClientTransport.Posix.TransportSecurity {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension TLSConfig.PrivateKeySource {
   /// Creates a key source from a `NIOSSLCustomPrivateKey`.
   ///
@@ -432,12 +437,14 @@ extension TLSConfig.PrivateKeySource {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension TLSConfig.CertificateSource {
   internal static func nioSSLCertificateSource(_ wrapped: NIOSSLCertificateSource) -> Self {
     return .transportSpecific(TransportSpecific(wrapped))
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension CertificateReloader {
   fileprivate func checkPrimed() throws -> ([NIOSSLCertificateSource], NIOSSLPrivateKeySource) {
     func explain(missingItem item: String) -> String {

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ClientTransport+Posix.swift
@@ -20,6 +20,7 @@ public import NIOCore  // has to be public because of EventLoopGroup param in in
 public import NIOPosix  // has to be public because of default argument value in init
 private import NIOSSL
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport {
   /// A `ClientTransport` using HTTP/2 built on top of `NIOPosix`.
   ///
@@ -129,6 +130,7 @@ extension HTTP2ClientTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.Posix {
   struct Connector: HTTP2Connector {
     private let config: HTTP2ClientTransport.Posix.Config
@@ -200,6 +202,7 @@ extension HTTP2ClientTransport.Posix {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.Posix {
   public struct Config: Sendable {
     /// Configuration for HTTP/2 connections.
@@ -266,6 +269,7 @@ extension HTTP2ClientTransport.Posix {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel.Config {
   init(posix: HTTP2ClientTransport.Posix.Config) {
     self.init(
@@ -277,6 +281,7 @@ extension GRPCChannel.Config {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientTransport where Self == HTTP2ClientTransport.Posix {
   /// Creates a new Posix based HTTP/2 client transport.
   ///

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -25,6 +25,7 @@ private import SwiftASN1
 private import Synchronization
 public import X509
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport {
   /// A `ServerTransport` using HTTP/2 built on top of `NIOPosix`.
   ///
@@ -198,8 +199,10 @@ extension HTTP2ServerTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.Posix {
   /// Context for Posix TransportSpecific
+  @available(gRPCSwiftNIOTransport 1.1, *)
   public struct Context: ServerContext.TransportSpecific {
     /// The peer certificate (if any) from the mTLS handshake
     public var peerCertificate: Certificate?
@@ -274,6 +277,7 @@ extension HTTP2ServerTransport.Posix {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerBootstrap {
   fileprivate func bind<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -299,6 +303,7 @@ extension ServerBootstrap {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerTransport where Self == HTTP2ServerTransport.Posix {
   /// Create a new `Posix` based HTTP/2 server transport.
   ///

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOClientBootstrap+SocketAddress.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOClientBootstrap+SocketAddress.swift
@@ -19,6 +19,7 @@ internal import GRPCNIOTransportCore
 internal import NIOCore
 internal import NIOPosix
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientBootstrap {
   func connect<Result: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -44,6 +45,7 @@ extension ClientBootstrap {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOPosix.VsockAddress {
   init(_ address: GRPCNIOTransportCore.SocketAddress.VirtualSocket) {
     self.init(

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
@@ -19,6 +19,7 @@ package import GRPCNIOTransportCore
 internal import NIOCertificateReloading
 internal import NIOSSL
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOSSLSerializationFormats {
   fileprivate init(_ format: TLSConfig.SerializationFormat) {
     switch format.wrapped {
@@ -30,6 +31,7 @@ extension NIOSSLSerializationFormats {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Sequence<TLSConfig.CertificateSource> {
   func sslCertificateSources() throws -> [NIOSSLCertificateSource] {
     var certificateSources: [NIOSSLCertificateSource] = []
@@ -75,6 +77,7 @@ extension Sequence<TLSConfig.CertificateSource> {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension TLSConfig.PrivateKeySource {
   enum _NIOSSLPrivateKeySource: TransportSpecific {
     case customPrivateKey(any (NIOSSLCustomPrivateKey & Hashable))
@@ -86,6 +89,7 @@ extension TLSConfig.PrivateKeySource {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOSSLPrivateKey {
   fileprivate static func makePrivateKey(
     from source: TLSConfig.PrivateKeySource
@@ -132,6 +136,7 @@ extension NIOSSLPrivateKey {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOSSLTrustRoots {
   fileprivate init(_ trustRoots: TLSConfig.TrustRootsSource) throws {
     switch trustRoots.wrapped {
@@ -182,6 +187,7 @@ extension NIOSSLTrustRoots {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension CertificateVerification {
   fileprivate init(
     _ verificationMode: TLSConfig.CertificateVerification
@@ -197,6 +203,7 @@ extension CertificateVerification {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension TLSConfiguration {
   package init(_ tlsConfig: HTTP2ServerTransport.Posix.TransportSecurity.TLS) throws {
     let certificateChain = try tlsConfig.certificateChain.sslCertificateSources()

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
@@ -21,6 +21,7 @@ public import Network
 private import struct Foundation.Data
 private import struct Foundation.URL
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.TransportServices {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -73,6 +74,7 @@ extension HTTP2ServerTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.TransportServices {
   public struct TLS: Sendable {
     /// How to verify the client certificate, if one is presented.
@@ -156,6 +158,7 @@ extension HTTP2ServerTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.TransportServices {
   /// The security configuration for this connection.
   public struct TransportSecurity: Sendable {
@@ -208,6 +211,7 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.TransportServices {
   public struct TLS: Sendable {
     /// How to verify the server certificate, if one is presented.
@@ -285,6 +289,7 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NWProtocolTLS.Options {
   func setUpVerifyBlock(trustRootsSource: TLSConfig.TrustRootsSource) {
     if let (verifyQueue, verifyBlock) = trustRootsSource.makeTrustRootsConfig() {
@@ -297,6 +302,7 @@ extension NWProtocolTLS.Options {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension TLSConfig.TrustRootsSource {
   internal func makeTrustRootsConfig() -> (DispatchQueue, sec_protocol_verify_t)? {
     switch self.wrapped {

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -22,6 +22,7 @@ public import NIOCore  // has to be public because of EventLoopGroup param in in
 
 private import Network
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport {
   /// A `ClientTransport` using HTTP/2 built on top of `NIOTransportServices`.
   ///
@@ -131,6 +132,7 @@ extension HTTP2ClientTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.TransportServices {
   struct Connector: HTTP2Connector {
     private let config: HTTP2ClientTransport.TransportServices.Config
@@ -197,6 +199,7 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ClientTransport.TransportServices {
   /// Configuration for the `TransportServices` transport.
   public struct Config: Sendable {
@@ -264,6 +267,7 @@ extension HTTP2ClientTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel.Config {
   init(transportServices config: HTTP2ClientTransport.TransportServices.Config) {
     self.init(
@@ -275,6 +279,7 @@ extension GRPCChannel.Config {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOTSConnectionBootstrap {
   fileprivate func connect<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -297,6 +302,7 @@ extension NIOTSConnectionBootstrap {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   /// Create a new `TransportServices` based HTTP/2 client transport.
   ///
@@ -330,6 +336,7 @@ extension ClientTransport where Self == HTTP2ClientTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NWProtocolTLS.Options {
   convenience init(
     _ tlsConfig: HTTP2ClientTransport.TransportServices.TLS,

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -26,6 +26,7 @@ private import Network
 
 private import Synchronization
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport {
   /// A NIO Transport Services-backed implementation of a server transport.
   public struct TransportServices: ServerTransport, ListeningServerTransport {
@@ -146,6 +147,7 @@ extension HTTP2ServerTransport {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2ServerTransport.TransportServices {
   /// Configuration for the `TransportServices` transport.
   public struct Config: Sendable {
@@ -211,6 +213,7 @@ extension HTTP2ServerTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NIOTSListenerBootstrap {
   fileprivate func bind<Output: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -233,6 +236,7 @@ extension NIOTSListenerBootstrap {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerTransport where Self == HTTP2ServerTransport.TransportServices {
   /// Create a new `TransportServices` based HTTP/2 server transport.
   ///
@@ -257,6 +261,7 @@ extension ServerTransport where Self == HTTP2ServerTransport.TransportServices {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NWProtocolTLS.Options {
   convenience init(_ tlsConfig: HTTP2ServerTransport.TransportServices.TLS) throws {
     self.init()

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ClientConnectionHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ClientConnectionHandlerTests.swift
@@ -23,6 +23,7 @@ import Testing
 
 struct ClientConnectionHandlerTests {
   @Test("Connection closed after max idle time")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func maxIdleTime() throws {
     let connection = try Connection(maxIdleTime: .minutes(5))
     try connection.activate()
@@ -50,6 +51,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Connection closed after max idle time with open streams")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func maxIdleTimeWhenOpenStreams() throws {
     let connection = try Connection(maxIdleTime: .minutes(5))
     try connection.activate()
@@ -75,6 +77,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Connection closed after keepalive with open streams")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveWithOpenStreams() throws {
     let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
@@ -105,6 +108,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Connection closed after keepalive with no open streams")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveWithNoOpenStreams() throws {
     let connection = try Connection(keepaliveTime: .minutes(1), allowKeepaliveWithoutCalls: true)
     try connection.activate()
@@ -127,6 +131,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Connection closed after keepalive with open streams and timeout")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveWithOpenStreamsTimingOut() throws {
     let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
@@ -165,6 +170,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Received PING frames are ignored")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func pingsAreIgnored() throws {
     let connection = try Connection()
     try connection.activate()
@@ -175,6 +181,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receiving GOAWAY results in close event")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func receiveGoAway() throws {
     let connection = try Connection()
     try connection.activate()
@@ -191,6 +198,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receiving GOAWAY with no open streams")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func receiveGoAwayWithOpenStreams() throws {
     let connection = try Connection()
     try connection.activate()
@@ -212,6 +220,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receiving GOAWAY with no error and then GOAWAY with protoco error")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func goAwayWithNoErrorThenGoAwayWithProtocolError() throws {
     let connection = try Connection()
     try connection.activate()
@@ -233,6 +242,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Outbound graceful close")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func outboundGracefulClose() throws {
     let connection = try Connection()
     try connection.activate()
@@ -247,6 +257,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receive initial SETTINGS")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func receiveInitialSettings() throws {
     let connection = try Connection()
     try connection.activate()
@@ -264,6 +275,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receive error when idle")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func receiveErrorWhenIdle() throws {
     let connection = try Connection()
     try connection.activate()
@@ -281,6 +293,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Receive error when streams are open")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func receiveErrorWhenStreamsAreOpen() throws {
     let connection = try Connection()
     try connection.activate()
@@ -301,6 +314,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Unexpected close while idle")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func unexpectedCloseWhenIdle() throws {
     let connection = try Connection()
     try connection.activate()
@@ -314,6 +328,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Unexpected close when streams are open")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func unexpectedCloseWhenStreamsAreOpen() throws {
     let connection = try Connection()
     try connection.activate()
@@ -328,6 +343,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Closes on error")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func closesOnError() throws {
     let connection = try Connection()
     try connection.activate()
@@ -341,6 +357,7 @@ struct ClientConnectionHandlerTests {
   }
 
   @Test("Doesn't close on stream error")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func doesNotCloseOnStreamError() throws {
     let connection = try Connection(maxIdleTime: .minutes(1))
     try connection.activate()

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -19,12 +19,17 @@ import GRPCNIOTransportCore
 
 // Equatable conformance for these types is 'best effort', this is sufficient for testing but not
 // for general use.
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection.Event: Equatable {}
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection.CloseReason: Equatable {}
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientConnectionEvent: Equatable {}
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientConnectionEvent.CloseReason: Equatable {}
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection.Event {
   static func == (lhs: Connection.Event, rhs: Connection.Event) -> Bool {
     switch (lhs, rhs) {
@@ -44,6 +49,7 @@ extension Connection.Event {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Connection.CloseReason {
   static func == (lhs: Connection.CloseReason, rhs: Connection.CloseReason) -> Bool {
     switch (lhs, rhs) {
@@ -62,6 +68,7 @@ extension Connection.CloseReason {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientConnectionEvent {
   static func == (lhs: ClientConnectionEvent, rhs: ClientConnectionEvent) -> Bool {
     switch (lhs, rhs) {
@@ -75,6 +82,7 @@ extension ClientConnectionEvent {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientConnectionEvent.CloseReason {
   static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionBackoffTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionBackoffTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class ConnectionBackoffTests: XCTestCase {
   func testUnjitteredBackoff() {
     let backoff = ConnectionBackoff(

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -24,6 +24,7 @@ import NIOPosix
 import Synchronization
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class ConnectionTests: XCTestCase {
   func testConnectThenClose() async throws {
     try await ConnectionTest.run(connector: .posix()) { context, event in
@@ -240,6 +241,7 @@ final class ConnectionTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ClientBootstrap {
   func connect<T: Sendable>(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -276,6 +278,7 @@ extension ClientBootstrap {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Metadata {
   init(_ sequence: some Sequence<Element>) {
     var metadata = Metadata()
@@ -292,6 +295,7 @@ extension Metadata {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class SNIRecordingConnector: HTTP2Connector {
   private let _sniHostnames: Mutex<[String?]>
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
@@ -21,6 +21,7 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCChannelTests: XCTestCase {
   func testDefaultServiceConfig() throws {
     var serviceConfig = ServiceConfig()
@@ -852,6 +853,7 @@ final class GRPCChannelTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel.Config {
   static var defaults: Self {
     Self(
@@ -863,12 +865,14 @@ extension GRPCChannel.Config {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Endpoint {
   init(_ addresses: GRPCNIOTransportCore.SocketAddress...) {
     self.init(addresses: addresses)
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCChannel {
   fileprivate func serverAddress() async throws -> String? {
     let values: Metadata.StringValues? = try await self.withStream(

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/LoadBalancerTest.swift
@@ -19,6 +19,7 @@ import GRPCNIOTransportCore
 import NIOPosix
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum LoadBalancerTest {
   struct Context {
     let servers: [(server: TestServer, address: GRPCNIOTransportCore.SocketAddress)]
@@ -166,6 +167,7 @@ enum LoadBalancerTest {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension LoadBalancerTest.Context {
   var roundRobin: RoundRobinLoadBalancer? {
     switch self.loadBalancer {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
@@ -21,6 +21,7 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class PickFirstLoadBalancerTests: XCTestCase {
   func testPickFirstConnectsToServer() async throws {
     try await LoadBalancerTest.pickFirst(servers: 1, connector: .posix()) { context, event in

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -21,6 +21,7 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class RoundRobinLoadBalancerTests: XCTestCase {
   func testMultipleConnectionsAreEstablished() async throws {
     try await LoadBalancerTest.roundRobin(servers: 3, connector: .posix()) { context, event in

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -21,6 +21,7 @@ import NIOHTTP2
 import NIOPosix
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class SubchannelTests: XCTestCase {
   func testMakeStreamOnIdleSubchannel() async throws {
     let subchannel = self.makeSubchannel(
@@ -584,6 +585,7 @@ final class SubchannelTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ConnectionBackoff {
   static func fixed(at interval: Duration, jitter: Double = 0.0) -> Self {
     return Self(initial: interval, max: interval, multiplier: 1.0, jitter: jitter)

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/RequestQueueTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class RequestQueueTests: XCTestCase {
   struct AnErrorToAvoidALeak: Error {}
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -21,6 +21,7 @@ import NIOCore
 import NIOHTTP2
 import NIOPosix
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum ConnectionTest {
   struct Context {
     var server: Server
@@ -61,6 +62,7 @@ enum ConnectionTest {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ConnectionTest {
   /// A server which only expected to accept a single connection.
   final class Server {
@@ -154,6 +156,7 @@ extension ConnectionTest {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ConnectionTest {
   /// Succeeds a promise when a SETTINGS frame ack has been read.
   private final class SucceedOnSettingsAck: ChannelInboundHandler {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
@@ -20,6 +20,7 @@ import NIOCore
 import NIOHTTP2
 import NIOPosix
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2Connector where Self == ThrowingConnector {
   /// A connector which throws the given error on a connect attempt.
   static func throwing(_ error: RPCError) -> Self {
@@ -27,6 +28,7 @@ extension HTTP2Connector where Self == ThrowingConnector {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2Connector where Self == NeverConnector {
   /// A connector which fatal errors if a connect attempt is made.
   static var never: Self {
@@ -34,6 +36,7 @@ extension HTTP2Connector where Self == NeverConnector {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension HTTP2Connector where Self == NIOPosixConnector {
   /// A connector which uses NIOPosix to establish a connection.
   static func posix(
@@ -53,6 +56,7 @@ extension HTTP2Connector where Self == NIOPosixConnector {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct ThrowingConnector: HTTP2Connector {
   private let error: RPCError
 
@@ -68,6 +72,7 @@ struct ThrowingConnector: HTTP2Connector {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct NeverConnector: HTTP2Connector {
   func establishConnection(
     to address: GRPCNIOTransportCore.SocketAddress,
@@ -77,6 +82,7 @@ struct NeverConnector: HTTP2Connector {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct NIOPosixConnector: HTTP2Connector {
   private let eventLoopGroup: any EventLoopGroup
   private let maxIdleTime: TimeAmount?

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/NameResolvers.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/NameResolvers.swift
@@ -17,6 +17,7 @@
 import GRPCCore
 import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension NameResolver {
   static func `static`(
     endpoints: [Endpoint],
@@ -42,6 +43,7 @@ extension NameResolver {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let result: Result<Element, any Error>
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
@@ -23,6 +23,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class TestServer: Sendable {
   private let eventLoopGroup: any EventLoopGroup
   private typealias Stream = NIOAsyncChannel<
@@ -159,6 +160,7 @@ final class TestServer: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension TestServer {
   enum RunHandler {
     case echo

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -24,6 +24,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCClientStreamHandlerTests: XCTestCase {
   func testH2FramesAreIgnored() throws {
     let handler = GRPCClientStreamHandler(
@@ -998,6 +999,7 @@ private enum TestError: Error {
   case assertionFailure(String)
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodDescriptor {
   static let testTest = Self(fullyQualifiedService: "test", method: "test")
 }

--- a/Tests/GRPCNIOTransportCoreTests/Client/HTTP2ClientTransportConfigTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/HTTP2ClientTransportConfigTests.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import GRPCNIOTransportCore
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2ClientTransportConfigTests: XCTestCase {
   func testCompressionDefaults() {
     let config = HTTP2ClientTransport.Config.Compression.defaults

--- a/Tests/GRPCNIOTransportCoreTests/Client/Resolver/DNSResolverTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Resolver/DNSResolverTests.swift
@@ -26,6 +26,7 @@ struct DNSResolverTests {
       ("::1", .ipv6(host: "::1", port: 80)),
     ] as [(String, SocketAddress)]
   )
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func resolve(host: String, expected: SocketAddress) async throws {
     // Note: This test checks the IPv4 and IPv6 addresses separately (instead of
     // `DNSResolver.resolve(host: "localhost", port: 80)`) because the ordering of the resulting

--- a/Tests/GRPCNIOTransportCoreTests/Client/Resolver/NameResolverRegistryTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Resolver/NameResolverRegistryTests.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import GRPCNIOTransportCore
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class NameResolverRegistryTests: XCTestCase {
   struct FailingResolver: NameResolverFactory {
     typealias Target = StringTarget

--- a/Tests/GRPCNIOTransportCoreTests/Client/Resolver/SocketAddressTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Resolver/SocketAddressTests.swift
@@ -17,6 +17,7 @@
 import GRPCNIOTransportCore
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class SocketAddressTests: XCTestCase {
   func testSocketAddressUnwrapping() {
     var address: SocketAddress = .ipv4(host: "foo", port: 42)

--- a/Tests/GRPCNIOTransportCoreTests/GRPCMessageDecoderTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCMessageDecoderTests.swift
@@ -21,6 +21,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCMessageDecoderTests: XCTestCase {
   func testReadMultipleMessagesWithoutCompression() throws {
     let firstMessage = {
@@ -218,6 +219,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCMessageFramer {
   mutating func next(
     compressor: Zlib.Compressor? = nil

--- a/Tests/GRPCNIOTransportCoreTests/GRPCMessageDeframerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCMessageDeframerTests.swift
@@ -18,6 +18,7 @@ import GRPCNIOTransportCore
 import NIOCore
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCMessageDeframerTests: XCTestCase {
   // Most of the functionality is tested by the 'GRPCMessageDecoder' tests.
 

--- a/Tests/GRPCNIOTransportCoreTests/GRPCMessageFramerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCMessageFramerTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCMessageFramerTests: XCTestCase {
   func testSingleWrite() throws {
     var framer = GRPCMessageFramer()

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -135,6 +135,7 @@ extension HPACKHeaders {
   ]
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCStreamClientStateMachineTests: XCTestCase {
   private func makeClientStateMachine(
     targetState: TargetStateMachineState,
@@ -1330,6 +1331,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCStreamServerStateMachineTests: XCTestCase {
   private func makeServerStateMachine(
     targetState: TargetStateMachineState,
@@ -2797,6 +2799,7 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension XCTestCase {
   func assertRejectedRPC(
     _ action: GRPCStreamStateMachine.OnMetadataReceived,
@@ -2836,6 +2839,7 @@ extension XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCStreamStateMachine.OnNextOutboundFrame {
   static func == (
     lhs: GRPCStreamStateMachine.OnNextOutboundFrame,
@@ -2856,4 +2860,5 @@ extension GRPCStreamStateMachine.OnNextOutboundFrame {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension GRPCStreamStateMachine.OnNextOutboundFrame: Equatable {}

--- a/Tests/GRPCNIOTransportCoreTests/Internal/ProcessUniqueIDTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/ProcessUniqueIDTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class ProcessUniqueIDTests: XCTestCase {
   func testProcessUniqueIDIsUnique() {
     var ids: Set<ProcessUniqueID> = []

--- a/Tests/GRPCNIOTransportCoreTests/Internal/TimerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/TimerTests.swift
@@ -21,6 +21,7 @@ import NIOEmbedded
 import Synchronization
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 internal final class TimerTests: XCTestCase {
   fileprivate struct CounterTimerHandler: NIOScheduledCallbackHandler {
     let counter = AtomicCounter(0)

--- a/Tests/GRPCNIOTransportCoreTests/Server/Compression/ZlibTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/Compression/ZlibTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class ZlibTests: XCTestCase {
   private let text = """
     Here's to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the

--- a/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandler+StateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandler+StateMachineTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
   private func makeStateMachine(
     allowKeepaliveWithoutCalls: Bool = false,

--- a/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
@@ -22,6 +22,7 @@ import Testing
 
 struct ServerConnectionManagementHandlerTests {
   @Test("Idle timeout on new connection")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func idleTimeoutOnNewConnection() throws {
     let connection = try Connection(maxIdleTime: .minutes(1))
     try connection.activate()
@@ -36,6 +37,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Idle timeout is cancelled when stream is opened")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func idleTimerIsCancelledWhenStreamIsOpened() throws {
     let connection = try Connection(maxIdleTime: .minutes(1))
     try connection.activate()
@@ -49,6 +51,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Idle timer starts when all streams are closed")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func idleTimerStartsWhenAllStreamsAreClosed() throws {
     let connection = try Connection(maxIdleTime: .minutes(1))
     try connection.activate()
@@ -70,6 +73,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Connection shutdown after max age is reached")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func maxAge() throws {
     let connection = try Connection(maxAge: .minutes(1))
     try connection.activate()
@@ -91,6 +95,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Graceful shutdown ratchets down last stream ID")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func gracefulShutdownRatchetsDownStreamID() throws {
     // This test uses the idle timeout to trigger graceful shutdown. The mechanism is the same
     // regardless of how it's triggered.
@@ -111,6 +116,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Graceful shutdown promoted to close after grace period")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func gracefulShutdownGracePeriod() throws {
     // This test uses the idle timeout to trigger graceful shutdown. The mechanism is the same
     // regardless of how it's triggered.
@@ -134,6 +140,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Keepalive works on new connection")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveOnNewConnection() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
@@ -157,6 +164,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Keepalive starts after read loop")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveStartsAfterReadLoop() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
@@ -185,6 +193,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Keepalive works on new connection without response")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func keepaliveOnNewConnectionWithoutResponse() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
@@ -209,6 +218,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Keepalive sent by client is policed")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func clientKeepalivePolicing() throws {
     let connection = try Connection(
       allowKeepaliveWithoutCalls: true,
@@ -237,6 +247,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Client keepalive works with permissible intervals")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func clientKeepaliveWithPermissibleIntervals() throws {
     let connection = try Connection(
       allowKeepaliveWithoutCalls: true,
@@ -255,6 +266,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Client keepalive works after reset state")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func clientKeepaliveResetState() throws {
     let connection = try Connection(
       allowKeepaliveWithoutCalls: true,
@@ -294,6 +306,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Closes on error")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func closesOnError() throws {
     let connection = try Connection()
     try connection.activate()
@@ -307,6 +320,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 
   @Test("Doesn't close on stream error")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func doesNotCloseOnStreamError() throws {
     let connection = try Connection(maxIdleTime: .minutes(1))
     try connection.activate()
@@ -328,6 +342,7 @@ struct ServerConnectionManagementHandlerTests {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandlerTests {
   private func testGracefulShutdown(
     connection: Connection,
@@ -371,6 +386,7 @@ extension ServerConnectionManagementHandlerTests {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ServerConnectionManagementHandlerTests {
   struct Connection {
     let channel: EmbeddedChannel

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -24,6 +24,7 @@ import XCTest
 
 @testable import GRPCNIOTransportCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class GRPCServerStreamHandlerTests: XCTestCase {
   private func makeServerStreamHandler(
     channel: any Channel,
@@ -1009,11 +1010,13 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 }
 
 struct ServerStreamHandlerTests {
+  @available(gRPCSwiftNIOTransport 1.0, *)
   struct ConnectionAndStreamHandlers {
     let streamHandler: GRPCServerStreamHandler
     let connectionHandler: ServerConnectionManagementHandler
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeServerConnectionAndStreamHandlers(
     channel: any Channel,
     scheme: Scheme = .http,
@@ -1050,6 +1053,7 @@ struct ServerStreamHandlerTests {
   }
 
   @Test("ChannelShouldQuiesceEvent is buffered and turns into RPC cancellation")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func shouldQuiesceEventIsBufferedBeforeHandleIsSet() async throws {
     let channel = EmbeddedChannel()
     let handler = self.makeServerConnectionAndStreamHandlers(channel: channel).streamHandler
@@ -1066,6 +1070,7 @@ struct ServerStreamHandlerTests {
   }
 
   @Test("ChannelShouldQuiesceEvent turns into RPC cancellation")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func shouldQuiesceEventTriggersCancellation() async throws {
     let channel = EmbeddedChannel()
     let handler = self.makeServerConnectionAndStreamHandlers(channel: channel).streamHandler
@@ -1083,6 +1088,7 @@ struct ServerStreamHandlerTests {
   }
 
   @Test("RST_STREAM turns into RPC cancellation")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func rstStreamTriggersCancellation() async throws {
     let channel = EmbeddedChannel()
     let handler = self.makeServerConnectionAndStreamHandlers(channel: channel).streamHandler
@@ -1103,6 +1109,7 @@ struct ServerStreamHandlerTests {
   }
 
   @Test("Connection FrameStats are updated when writing headers or data frames")
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func connectionFrameStatsAreUpdatedAccordingly() async throws {
     let channel = EmbeddedChannel()
     let handlers = self.makeServerConnectionAndStreamHandlers(channel: channel)

--- a/Tests/GRPCNIOTransportCoreTests/Server/HTTP2ServerTransportConfigTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/HTTP2ServerTransportConfigTests.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import GRPCNIOTransportCore
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2ServerTransportConfigTests: XCTestCase {
   func testCompressionDefaults() {
     let config = HTTP2ServerTransport.Config.Compression.defaults

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/AtomicCounter.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/AtomicCounter.swift
@@ -16,6 +16,7 @@
 
 import Synchronization
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class AtomicCounter: Sendable {
   private let counter: Atomic<Int>
 

--- a/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Test Utilities/MethodDescriptor+Common.swift
@@ -16,6 +16,7 @@
 
 import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodDescriptor {
   static var echoGet: Self {
     MethodDescriptor(fullyQualifiedService: "echo.Echo", method: "Get")
@@ -26,6 +27,7 @@ extension MethodDescriptor {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodConfig.Name {
   init(_ descriptor: MethodDescriptor) {
     self = MethodConfig.Name(

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlClient.swift
@@ -16,6 +16,7 @@
 
 import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 internal struct ControlClient<Transport> where Transport: ClientTransport {
   internal let client: GRPCCore.GRPCClient<Transport>
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlMessages.swift
@@ -17,6 +17,7 @@
 import Foundation
 import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct ControlInput: Codable {
   /// Whether metadata should be echo'd back in the initial metadata.
   ///

--- a/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/ControlService.swift
@@ -17,6 +17,7 @@
 import Foundation
 import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct ControlService: RegistrableRPCService {
   func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>) {
     router.registerHandler(
@@ -87,6 +88,7 @@ struct ControlService: RegistrableRPCService {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ControlService {
   private func waitForCancellation(
     request: ServerRequest<CancellationKind>,
@@ -258,6 +260,7 @@ extension ControlService {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ControlService {
   struct PeerInfoResponse: Codable {
     struct PeerInfo: Codable {
@@ -270,6 +273,7 @@ extension ControlService {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension Metadata {
   fileprivate func echo() -> Self {
     var copy = Metadata()
@@ -300,6 +304,7 @@ private struct UnsafeTransfer<Wrapped> {
 
 extension UnsafeTransfer: @unchecked Sendable {}
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct PeerInfoClientInterceptor: ClientInterceptor {
   func intercept<Input, Output>(
     request: StreamingClientRequest<Input>,

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2ServerTransport+DebugTests.swift
@@ -23,6 +23,7 @@ import Testing
 @Suite("ChannelDebugCallbacks")
 struct ChannelDebugCallbackTests {
   @Test(arguments: TransportKind.supportsDebugCallbacks, TransportKind.supportsDebugCallbacks)
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func debugCallbacksAreCalled(serverKind: TransportKind, clientKind: TransportKind) async throws {
     // Validates the callbacks are called appropriately by setting up callbacks which increment
     // counters and then returning those stats from a gRPC service. The client's interactions with
@@ -96,6 +97,7 @@ struct ChannelDebugCallbackTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeServerTransport(
     kind: TransportKind,
     address: GRPCNIOTransportCore.SocketAddress,
@@ -130,6 +132,7 @@ struct ChannelDebugCallbackTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeClientTransport(
     kind: TransportKind,
     target: any ResolvableTarget,

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOPosixTests.swift
@@ -20,6 +20,7 @@ import GRPCNIOTransportHTTP2Posix
 import NIOSSL
 import XCTest
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.Posix(

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportNIOTransportServicesTests.swift
@@ -21,6 +21,7 @@ import GRPCNIOTransportHTTP2TransportServices
 import XCTest
 import NIOSSL
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCNIOTransportCore.HTTP2ServerTransport.TransportServices(

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -35,6 +35,7 @@ struct HTTP2TransportTLSEnabledTests {
     arguments: TransportKind.clientsWithTLS,
     TransportKind.serversWithTLS
   )
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func testRPC_Defaults_OK(
     clientTransport: TransportKind,
     serverTransport: TransportKind
@@ -59,6 +60,7 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.2, *)
   final class TransportSpecificInterceptor: ServerInterceptor {
     let clientCert: [UInt8]
     init(_ clientCert: [UInt8]) {
@@ -87,6 +89,7 @@ struct HTTP2TransportTLSEnabledTests {
     "Using the mTLS defaults, and with Posix transport, validate we get the peer cert on the server",
     arguments: [TransportKind.posix]
   )
+  @available(gRPCSwiftNIOTransport 1.2, *)
   func testRPC_mTLS_TransportContext_OK(supportedTransport: TransportKind) async throws {
     let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
     let clientConfig = self.makeMTLSClientConfig(
@@ -116,6 +119,7 @@ struct HTTP2TransportTLSEnabledTests {
     arguments: TransportKind.clientsWithTLS,
     TransportKind.clientsWithTLS
   )
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func testRPC_mTLS_OK(
     clientTransport: TransportKind,
     serverTransport: TransportKind
@@ -147,6 +151,7 @@ struct HTTP2TransportTLSEnabledTests {
     arguments: TransportKind.clientsWithTLS,
     TransportKind.clientsWithTLS
   )
+  @available(gRPCSwiftNIOTransport 1.0, *)
   // Verification should fail because the custom hostname is missing on the client.
   func testClientFailsServerValidation(
     clientTransport: TransportKind,
@@ -213,6 +218,7 @@ struct HTTP2TransportTLSEnabledTests {
     arguments: TransportKind.clientsWithTLS,
     TransportKind.clientsWithTLS
   )
+  @available(gRPCSwiftNIOTransport 1.0, *)
   // Verification should fail because the client does not offer a cert that
   // the server can use for mutual verification.
   func testServerFailsClientValidation(
@@ -295,6 +301,7 @@ struct HTTP2TransportTLSEnabledTests {
     var transport: Transport
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   enum ClientConfig {
     typealias Posix = Config<
       HTTP2ClientTransport.Posix.Config,
@@ -311,6 +318,7 @@ struct HTTP2TransportTLSEnabledTests {
     #endif
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   enum ServerConfig {
     typealias Posix = Config<
       HTTP2ServerTransport.Posix.Config,
@@ -327,6 +335,7 @@ struct HTTP2TransportTLSEnabledTests {
     #endif
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultPlaintextPosixClientConfig() -> ClientConfig.Posix {
     ClientConfig.Posix(
       security: .plaintext,
@@ -339,6 +348,7 @@ struct HTTP2TransportTLSEnabledTests {
   }
 
   #if canImport(Network)
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultPlaintextTSClientConfig() -> ClientConfig.TransportServices {
     ClientConfig.TransportServices(
       security: .plaintext,
@@ -351,6 +361,7 @@ struct HTTP2TransportTLSEnabledTests {
   }
   #endif
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultTLSClientConfig(
     for transportSecurity: TransportKind,
     certificateKeyPairs: SelfSignedCertificateKeyPairs,
@@ -385,6 +396,7 @@ struct HTTP2TransportTLSEnabledTests {
   }
 
   #if canImport(Network)
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeSecIdentityProvider(
     certificateBytes: [UInt8],
     privateKeyBytes: [UInt8]
@@ -417,6 +429,7 @@ struct HTTP2TransportTLSEnabledTests {
   }
   #endif
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeMTLSClientConfig(
     for transportKind: TransportKind,
     certificateKeyPairs: SelfSignedCertificateKeyPairs,
@@ -458,16 +471,19 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultPlaintextPosixServerConfig() -> ServerConfig.Posix {
     ServerConfig.Posix(security: .plaintext, transport: .defaults)
   }
 
   #if canImport(Network)
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultPlaintextTSServerConfig() -> ServerConfig.TransportServices {
     ServerConfig.TransportServices(security: .plaintext, transport: .defaults)
   }
   #endif
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeDefaultTLSServerConfig(
     for transportKind: TransportKind,
     certificateKeyPairs: SelfSignedCertificateKeyPairs
@@ -498,6 +514,7 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func makeMTLSServerConfig(
     for transportKind: TransportKind,
     certificateKeyPairs: SelfSignedCertificateKeyPairs,
@@ -541,6 +558,7 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   func withClientAndServer(
     clientConfig: ClientConfig,
     serverConfig: ServerConfig,
@@ -604,6 +622,7 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 1.0, *)
   private func executeUnaryRPC(control: ControlClient<NIOClientTransport>) async throws {
     let input = ControlInput.with { $0.numberOfMessages = 1 }
     let request = ClientRequest(message: input)

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTests.swift
@@ -23,6 +23,7 @@ import XCTest
 
 import protocol NIOCore.Channel
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2TransportTests: XCTestCase {
   // A combination of client and server transport kinds.
   struct Transport: Sendable, CustomStringConvertible {
@@ -1768,6 +1769,7 @@ final class HTTP2TransportTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension [HTTP2TransportTests.Transport] {
   static let supported: [HTTP2TransportTests.Transport] = TransportKind.servers.flatMap { server in
     TransportKind.clients.map { client in
@@ -1776,6 +1778,7 @@ extension [HTTP2TransportTests.Transport] {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension ControlInput {
   fileprivate static let echoMetadata = Self.with {
     $0.echoMetadataInHeaders = true
@@ -1827,6 +1830,7 @@ extension ControlInput {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension CompressionAlgorithm {
   var name: String {
     switch self {

--- a/Tests/GRPCNIOTransportHTTP2Tests/TLSConfigurationTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/TLSConfigurationTests.swift
@@ -38,6 +38,7 @@ struct TLSConfigurationTests {
   }
 
   @Test("Client custom private key")
+  @available(gRPCSwiftNIOTransport 1.2, *)
   func clientTLSCustomPrivateKey() throws {
     let custom = NoOpCustomPrivateKey()
     let config = HTTP2ClientTransport.Posix.TransportSecurity.tls {
@@ -51,6 +52,7 @@ struct TLSConfigurationTests {
   }
 
   @Test("Server custom private key")
+  @available(gRPCSwiftNIOTransport 1.2, *)
   func serverTLSCustomPrivateKey() throws {
     let custom = NoOpCustomPrivateKey()
     let config = HTTP2ServerTransport.Posix.TransportSecurity.tls(
@@ -74,6 +76,7 @@ struct TLSConfigurationTests {
   }
 
   @Test("Client cert reloader is set")
+  @available(gRPCSwiftNIOTransport 1.2, *)
   func clientCertificateReloader() throws {
     let config = try HTTP2ClientTransport.Posix.TransportSecurity.mTLS(
       certificateReloader: StaticCertLoader()
@@ -87,6 +90,7 @@ struct TLSConfigurationTests {
   }
 
   @Test("Server cert reloader is set", arguments: [false, true])
+  @available(gRPCSwiftNIOTransport 1.2, *)
   func serverCertificateReloader(isMTLS: Bool) throws {
     let config: HTTP2ServerTransport.Posix.TransportSecurity
     if isMTLS {
@@ -108,6 +112,7 @@ struct TLSConfigurationTests {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ClientTransport.Posix.TransportSecurity {
   var tls: TLS? {
     switch self.wrapped {
@@ -119,6 +124,7 @@ extension HTTP2ClientTransport.Posix.TransportSecurity {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension HTTP2ServerTransport.Posix.TransportSecurity {
   var tls: TLS? {
     switch self.wrapped {
@@ -130,6 +136,7 @@ extension HTTP2ServerTransport.Posix.TransportSecurity {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.2, *)
 extension NIOSSLPrivateKeySource {
   var privateKey: NIOSSLPrivateKey? {
     switch self {

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/HTTP2StatusCodeServer.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/HTTP2StatusCodeServer.swift
@@ -23,6 +23,7 @@ import NIOPosix
 /// An HTTP/2 test server which only responds to request headers by sending response headers and
 /// then closing. Each stream will be closed with the ":status" set to the value of the
 /// "response-status" header field in the request headers.
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class HTTP2StatusCodeServer: Sendable {
   private let address: EventLoopPromise<GRPCNIOTransportCore.SocketAddress.IPv4>
   private let eventLoopGroup: MultiThreadedEventLoopGroup

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONCoding.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONCoding.swift
@@ -26,6 +26,7 @@ import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
 #endif
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct JSONCoder<Message: Codable>: MessageSerializer, MessageDeserializer {
   func serialize<Bytes: GRPCContiguousBytes>(_ message: Message) throws -> Bytes {
     let json = JSONEncoder()

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONSerializing.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/JSONSerializing.swift
@@ -17,6 +17,7 @@
 import Foundation
 import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct JSONSerializer<Message: Encodable>: MessageSerializer {
   private let encoder = JSONEncoder()
 
@@ -26,6 +27,7 @@ struct JSONSerializer<Message: Encodable>: MessageSerializer {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct JSONDeserializer<Message: Decodable>: MessageDeserializer {
   private let decoder = JSONDecoder()
 

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/StatsService.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/StatsService.swift
@@ -17,6 +17,7 @@
 import GRPCCore
 import Synchronization
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 final class DebugCallbackStats: Sendable {
   let tcpListenersBound: Atomic<Int>
   let tcpConnectionsAccepted: Atomic<Int>
@@ -50,6 +51,7 @@ final class DebugCallbackStats: Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct StatsService {
   private let stats: DebugCallbackStats
 
@@ -62,6 +64,7 @@ struct StatsService {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension StatsService: RegistrableRPCService {
   func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>) {
     router.registerHandler(
@@ -79,6 +82,7 @@ extension StatsService: RegistrableRPCService {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 struct StatsClient<Transport: ClientTransport> {
   private let underlying: GRPCClient<Transport>
 
@@ -99,6 +103,7 @@ struct StatsClient<Transport: ClientTransport> {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 extension MethodDescriptor {
   static let getStats = Self(fullyQualifiedService: "StatsService", method: "GetStats")
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/TransportKind.swift
@@ -45,6 +45,7 @@ enum TransportKind: CaseIterable, Hashable, Sendable {
   }
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum NIOClientTransport: ClientTransport {
   case wrappedChannel(HTTP2ClientTransport.WrappedChannel)
   case posix(HTTP2ClientTransport.Posix)
@@ -139,6 +140,7 @@ enum NIOClientTransport: ClientTransport {
 
 }
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 enum NIOServerTransport: ServerTransport, ListeningServerTransport {
   case posix(HTTP2ServerTransport.Posix)
   #if canImport(Network)


### PR DESCRIPTION
Motivation:

It's hard for packages to incrementally adopt gRPC with platforms in the package manifest as it requires packages to include platforms in their manifest or mint a new major version.

Modifications:

- Move platform availability onto source code
- Check annotations in CI

Result:

Easier to adopt