### PR TITLE
Add availability to `ConstantAsyncSequence`

### DIFF
--- a/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift
@@ -16,6 +16,7 @@
 
 internal import GRPCCore
 
+@available(gRPCSwiftNIOTransport 1.0, *)
 private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let element: Element
 


### PR DESCRIPTION
We were running into build issues like this

> grpc-swift-nio-transport/Sources/GRPCNIOTransportCore/Internal/ConstantAsyncSequence.swift:37:17: error: concurrency is only available in macOS 10.15.0 or newer

when building this package on macOS. It looks like there is just a missing availability annotation.