### PR TITLE
Add deprecation warnings

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
@@ -19,6 +19,7 @@ public import NIOCore
 
 /// A namespace for the HTTP/2 client transport.
 @available(gRPCSwiftNIOTransport 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public enum HTTP2ClientTransport {}
 
 @available(gRPCSwiftNIOTransport 1.0, *)

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
@@ -20,6 +20,7 @@ internal import NIOHTTP2
 
 /// A namespace for the HTTP/2 server transport.
 @available(gRPCSwiftNIOTransport 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public enum HTTP2ServerTransport {}
 
 @available(gRPCSwiftNIOTransport 1.0, *)


### PR DESCRIPTION
Motivation:

gRPC Swift v2 has moved to a new repo, grpc-swift-2 and as a result this package has a new major version. That's not all that discoverable.

Modifications:

Deprecate commonly used high-level types with a link to a forums post explaining the move.

Result:

Users are notified about the move