### PR TITLE
fix dns resolver for android build grpc-swift 2

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Resolver/DNSResolver.swift
@@ -18,6 +18,8 @@ private import Dispatch
 
 #if canImport(Darwin)
 private import Darwin
+#elseif canImport(Android)
+private import Android
 #elseif canImport(Glibc)
 private import Glibc
 #elseif canImport(Musl)
@@ -141,11 +143,7 @@ extension DNSResolver {
     package let description: String
 
     package init(code: CInt) {
-      if let errorMessage = gai_strerror(code) {
-        self.description = String(cString: errorMessage)
-      } else {
-        self.description = "Unknown error: \(code)"
-      }
+      self.description = String(validatingCString: gai_strerror(code)) ?? "Unknown error: \(code)"
     }
   }
 }


### PR DESCRIPTION
Hi, I tried to build grpc-swift 2 for Android and ran into a problem that grpc-swift-nio-transport is not building.
Made a fix to fix the library, now grpc-swift-nio-transport and grpc-swift 2 builds successfully on Android.
Plus, the other day they added Wasm and Android support to the Swift Package Index: https://swiftpackageindex.com/blog/adding-wasm-and-android-compatibility-testing