### PR TITLE
Avoid deprecation warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
-    from: "2.31.0"
+    from: "2.33.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",

--- a/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/NIOSSL+GRPC.swift
@@ -54,9 +54,7 @@ extension Sequence<TLSConfig.CertificateSource> {
       case .file(let path, let serializationFormat):
         switch serializationFormat.wrapped {
         case .der:
-          certificateSources.append(
-            .certificate(try NIOSSLCertificate(file: path, format: .der))
-          )
+          try certificateSources.append(.certificate(NIOSSLCertificate.fromDERFile(path)))
 
         case .pem:
           let certificates = try NIOSSLCertificate.fromPEMFile(path).map {
@@ -157,7 +155,7 @@ extension NIOSSLTrustRoots {
           case .pem:
             certificates.append(contentsOf: try NIOSSLCertificate.fromPEMFile(path))
           case .der:
-            certificates.append(try NIOSSLCertificate(file: path, format: .der))
+            certificates.append(try NIOSSLCertificate.fromDERFile(path))
           }
 
         case .transportSpecific(let specific):
@@ -174,7 +172,7 @@ extension NIOSSLTrustRoots {
             case "pem":
               certificates.append(contentsOf: try NIOSSLCertificate.fromPEMFile(path))
             case "der":
-              certificates.append(try NIOSSLCertificate(file: path, format: .der))
+              certificates.append(try NIOSSLCertificate.fromDERFile(path))
             default:
               throw RPCError(
                 code: .invalidArgument,


### PR DESCRIPTION
Motivation:

NIOSSL deprecated an init on NIOSSLCertificate. This now warns and causes some CI jobs to fail as a result.

Modifications:

- Switch to new API

Result:

No warnings, nightly CI passes