### PR TITLE
Use new http/2 frame delegate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.35.0"
+    from: "1.38.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -79,13 +79,10 @@ extension ChannelPipeline.SynchronousOperations {
     var http2HandlerStreamConfiguration = NIOHTTP2Handler.StreamConfiguration()
     http2HandlerStreamConfiguration.targetWindowSize = clampedTargetWindowSize
 
-    let boundConnectionManagementHandler = NIOLoopBound(
-      serverConnectionHandler.syncView,
-      eventLoop: self.eventLoop
-    )
     let streamMultiplexer = try self.configureAsyncHTTP2Pipeline(
       mode: .server,
       streamDelegate: serverConnectionHandler.http2StreamDelegate,
+      frameDelegate: serverConnectionHandler.syncView,
       configuration: NIOHTTP2Handler.Configuration(
         connection: http2HandlerConnectionConfiguration,
         stream: http2HandlerStreamConfiguration
@@ -98,8 +95,7 @@ extension ChannelPipeline.SynchronousOperations {
           acceptedEncodings: compressionConfig.enabledAlgorithms,
           maxPayloadSize: rpcConfig.maxRequestPayloadSize,
           methodDescriptorPromise: methodDescriptorPromise,
-          eventLoop: streamChannel.eventLoop,
-          connectionManagementHandler: boundConnectionManagementHandler.value
+          eventLoop: streamChannel.eventLoop
         )
         try streamChannel.pipeline.syncOperations.addHandler(streamHandler)
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -116,24 +116,12 @@ extension ConnectionTest {
             let h2 = NIOHTTP2Handler(mode: .server)
             let mux = HTTP2StreamMultiplexer(mode: .server, channel: channel) { stream in
               let sync = stream.pipeline.syncOperations
-              let connectionManagementHandler = ServerConnectionManagementHandler(
-                eventLoop: stream.eventLoop,
-                maxIdleTime: nil,
-                maxAge: nil,
-                maxGraceTime: nil,
-                keepaliveTime: nil,
-                keepaliveTimeout: nil,
-                allowKeepaliveWithoutCalls: false,
-                minPingIntervalWithoutCalls: .minutes(5),
-                requireALPN: false
-              )
               let handler = GRPCServerStreamHandler(
                 scheme: .http,
                 acceptedEncodings: .none,
                 maxPayloadSize: .max,
                 methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
-                eventLoop: stream.eventLoop,
-                connectionManagementHandler: connectionManagementHandler.syncView
+                eventLoop: stream.eventLoop
               )
 
               return stream.eventLoop.makeCompletedFuture {

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Utilities/TestServer.swift
@@ -73,24 +73,12 @@ final class TestServer: Sendable {
         let sync = channel.pipeline.syncOperations
         let multiplexer = try sync.configureAsyncHTTP2Pipeline(mode: .server) { stream in
           stream.eventLoop.makeCompletedFuture {
-            let connectionManagementHandler = ServerConnectionManagementHandler(
-              eventLoop: stream.eventLoop,
-              maxIdleTime: nil,
-              maxAge: nil,
-              maxGraceTime: nil,
-              keepaliveTime: nil,
-              keepaliveTimeout: nil,
-              allowKeepaliveWithoutCalls: false,
-              minPingIntervalWithoutCalls: .minutes(5),
-              requireALPN: false
-            )
             let handler = GRPCServerStreamHandler(
               scheme: .http,
               acceptedEncodings: .all,
               maxPayloadSize: .max,
               methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
-              eventLoop: stream.eventLoop,
-              connectionManagementHandler: connectionManagementHandler.syncView
+              eventLoop: stream.eventLoop
             )
 
             try stream.pipeline.syncOperations.addHandlers(handler)


### PR DESCRIPTION
Motivation:

When the server monitors client pings it resets its stream count after writing each HEADERS or DATA frame. At the moment this is done by stream channels when they write a frame into the parent channel. However, this isn't correct: the parent channel may choose to delay sending a frame or may chunk DATA frames up to respect various limits.

Modifications:

- Use the new http/2 frame delegate which is notified when the parent channel does the write

Result:

- https://github.com/grpc/grpc-swift-2/issues/5