### PR TITLE
Fix hanging graceful channel shutdown by cleaning up state.

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -834,6 +834,14 @@ extension GRPCChannel.StateMachine {
         case .idle, .connecting, .transientFailure, .shutdown:
           ()
         }
+      } else {
+        // In this case the LB is neither current nor next.
+        switch connectivityState {
+        case .shutdown:
+          state.past.removeValue(forKey: id)
+        case .idle, .connecting, .ready, .transientFailure:
+          ()
+        }
       }
 
       self.state = .running(state)

--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -395,15 +395,13 @@ extension PickFirstLoadBalancer.State.Active {
           } else {
             onUpdate = .publishStateChange(connectivityState)
           }
-
-          self.current = next
-          self.isCurrentGoingAway = false
         } else {
           // No state change to publish, just roll over.
           onUpdate = self.current.map { .close($0) } ?? .none
-          self.current = next
-          self.isCurrentGoingAway = false
         }
+        self.current = next
+        self.next = nil
+        self.isCurrentGoingAway = false
 
       case .idle, .connecting, .transientFailure, .shutdown:
         onUpdate = .none

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelTests.swift
@@ -619,13 +619,14 @@ final class GRPCChannelTests: XCTestCase {
 
           channel.beginGracefulShutdown()
 
-        case .shutdown:
-          group.cancelAll()
-
         default:
           ()
         }
       }
+
+      let result = await group.nextResult()!
+      group.cancelAll()
+      return try result.get()
     }
   }
 

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/LoadBalancers/PickFirstLoadBalancerTests.swift
@@ -124,8 +124,8 @@ final class PickFirstLoadBalancerTests: XCTestCase {
         // Should remain in the ready state
         try await XCTPoll(every: .milliseconds(10)) {
           context.servers[0].server.clients.isEmpty
-          && context.servers[1].server.clients.isEmpty
-          && context.servers[2].server.clients.count == 1
+            && context.servers[1].server.clients.isEmpty
+            && context.servers[2].server.clients.count == 1
         }
 
         context.loadBalancer.close()


### PR DESCRIPTION
Corrects two scenarios where stale state in the load balancer could prevent a graceful channel shutdown.

Previously, multiple endpoint updates or changes to the load balancer could leave undiscarded subchannels or old load balancers in the channel's state, blocking a clean shutdown.

This change ensures that previous subchannels and load balancers are fully removed from state when they shutdown. This also corrects a related test, which had been passing incorrectly due to an explicit cancellation masking the issue.