### PR TITLE
Add RST_STREAM info to errors

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -132,8 +132,8 @@ extension GRPCClientStreamHandler {
         context.fireErrorCaught(error)
       }
 
-    case .rstStream:
-      self.handleUnexpectedInboundClose(context: context, reason: .streamReset)
+    case .rstStream(let errorCode):
+      self.handleUnexpectedInboundClose(context: context, reason: .streamReset(errorCode))
 
     case .ping, .goAway, .priority, .settings, .pushPromise, .windowUpdate,
       .alternativeService, .origin:

--- a/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Server/GRPCServerStreamHandler.swift
@@ -202,8 +202,8 @@ extension GRPCServerStreamHandler {
         context.fireErrorCaught(error)
       }
 
-    case .rstStream:
-      self.handleUnexpectedInboundClose(context: context, reason: .streamReset)
+    case .rstStream(let errorCode):
+      self.handleUnexpectedInboundClose(context: context, reason: .streamReset(errorCode))
 
     case .ping, .goAway, .priority, .settings, .pushPromise, .windowUpdate,
       .alternativeService, .origin:

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -954,7 +954,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       .status(
         .init(
           code: .unavailable,
-          message: "Stream unexpectedly closed: a RST_STREAM frame was received."
+          message: "Stream unexpectedly closed: received RST_STREAM frame (0x2: internal error)."
         ),
         [:]
       )

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import NIOCore
 import NIOEmbedded
 import NIOHPACK
+import NIOHTTP2
 import XCTest
 
 @testable import GRPCNIOTransportCore
@@ -975,10 +976,10 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
         Status(code: .unavailable, message: "Stream unexpectedly closed.")
       ),
       (
-        GRPCStreamStateMachine.UnexpectedInboundCloseReason.streamReset,
+        GRPCStreamStateMachine.UnexpectedInboundCloseReason.streamReset(.noError),
         Status(
           code: .unavailable,
-          message: "Stream unexpectedly closed: a RST_STREAM frame was received."
+          message: "Stream unexpectedly closed: received RST_STREAM frame (0x0: no error)."
         )
       ),
       (
@@ -1022,7 +1023,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
   func testUnexpectedCloseWhenServerClosed() throws {
     let closeReasons = [
       GRPCStreamStateMachine.UnexpectedInboundCloseReason.channelInactive,
-      .streamReset,
+      .streamReset(.noError),
       .errorThrown(RPCError(code: .deadlineExceeded, message: "Test error")),
     ]
     let states = [
@@ -2470,10 +2471,10 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
         RPCError(code: .unavailable, message: "Stream unexpectedly closed.")
       ),
       (
-        GRPCStreamStateMachine.UnexpectedInboundCloseReason.streamReset,
+        GRPCStreamStateMachine.UnexpectedInboundCloseReason.streamReset(.noError),
         RPCError(
           code: .unavailable,
-          message: "Stream unexpectedly closed: a RST_STREAM frame was received."
+          message: "Stream unexpectedly closed: received RST_STREAM frame (0x0: no error)."
         )
       ),
       (
@@ -2514,7 +2515,7 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
   func testUnexpectedCloseWhenClientClosed() throws {
     let closeReasons = [
       GRPCStreamStateMachine.UnexpectedInboundCloseReason.channelInactive,
-      .streamReset,
+      .streamReset(.noError),
       .errorThrown(RPCError(code: .deadlineExceeded, message: "Test error")),
     ]
     let states = [

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -981,7 +981,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       )
     ) { error in
       XCTAssertEqual(error.code, .unavailable)
-      XCTAssertEqual(error.message, "Stream unexpectedly closed: a RST_STREAM frame was received.")
+      XCTAssertEqual(
+        error.message,
+        "Stream unexpectedly closed: received RST_STREAM frame (0x2: internal error)."
+      )
     }
 
     // We should now be closed: check we can't write anymore.


### PR DESCRIPTION
Motivation:

If a stream is reset by a remote peer the synthesized status doesn't include the http/2 error code from the RST_STREAM frame which makes debugging harder.

Modifications:

- Add the http/2 error code to the status message

Result:

Better error messages