### PR TITLE
Propagate unexpected close events

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Client/GRPCClientStreamHandler.swift
@@ -167,7 +167,7 @@ extension GRPCClientStreamHandler {
     context: ChannelHandlerContext,
     reason: GRPCStreamStateMachine.UnexpectedInboundCloseReason
   ) {
-    switch self.stateMachine.unexpectedInboundClose(reason: reason) {
+    switch self.stateMachine.unexpectedClose(reason: reason) {
     case .forwardStatus_clientOnly(let status):
       context.fireChannelRead(self.wrapInboundOut(.status(status, [:])))
     case .doNothing:

--- a/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -454,14 +454,13 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ]
     )
 
-    // Try writing and assert it throws to make sure we don't allow writes
-    // after closing.
+    // Writing after EOS is an error.
     XCTAssertThrowsError(
       ofType: RPCError.self,
       try channel.writeOutbound(trailers)
     ) { error in
       XCTAssertEqual(error.code, .internalError)
-      XCTAssertEqual(error.message, "Invalid state")
+      XCTAssertEqual(error.message, "Can't write status, stream has already closed")
     }
   }
 


### PR DESCRIPTION
Motivation:

When a stream is unexpectedly closed (i.e. the http/2 stream is reset) the server RPC handler is notified that the RPC has been cancelled (via the cancellation context) so that it can to stop doing work. However, in some situations this isn't respected which can lead to servers continuing to do work for an orphaned RPC.

This was the result of a bug in the server state machine which incorrectly ignored these events when the client side of the stream had closed.

This uncovered a second bug where the server stream state machine would treat sending a status on a closed stream as an invalid state transition. This isn't correct: this is possible because writing the stats from an async context can race with the stream being closed by other means such as the stream being reset.

Modifications:

- Rename 'handleUnexpectedInboundClose' to 'handleUnexpectedClose'. The "inbound" is misleading as the function is called when the whole stream is closed, not just the inbound side.
- Propagate errors in the server stream handler when the client side is closed. This results in the cancellation flag getting set.
- Don't treat writing the status in the closed state as an invalid state transition, fail the write promise instead.

Result:

RPC cancellation is propagated when an RPC is cancelled by the client after it has sent end of stream.