### PR TITLE
Enable access to the peer's certificate chain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-certificates.git",
-    from: "1.5.0"
+    from: "1.14.0"
   ),
   .package(
     url: "https://github.com/apple/swift-asn1.git",

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -189,20 +189,21 @@ extension HTTP2ServerTransport {
         listenerFactory: factory
       ) { channel in
         var context = HTTP2ServerTransport.Posix.Context()
+
         do {
-          if let peerCert = try await channel.nioSSL_peerCertificate().get() {
+          // The validadted certificate chain is only available when using a custom verification callback, while the
+          // peer certificate is only available when using the BoringSSL backend. But if we can get the certificate
+          // chain, we can set the peer certificate (the leaf of the chain) as well.
+          if let peerCertificateChain =
+            try await channel.nioSSL_peerValidatedCertificateChain().get(),
+            let peerCertificateChain = try? X509.ValidatedCertificateChain(peerCertificateChain)
+          {
+            context.peerCertificate = peerCertificateChain.leaf
+            context.peerCertificateChain = peerCertificateChain
+          } else if let peerCert = try await channel.nioSSL_peerCertificate().get() {
             let serialized = try peerCert.toDERBytes()
             let swiftCert = try Certificate(derEncoded: serialized)
             context.peerCertificate = swiftCert
-          }
-        } catch {}
-
-        do {
-          if let peerValidatedCertificateChain =
-            try await channel.nioSSL_peerValidatedCertificateChain().get()
-          {
-            context.peerValidatedCertificateChain =
-              try? peerValidatedCertificateChain.usingX509Certificates()
           }
         } catch {}
 
@@ -234,7 +235,7 @@ extension HTTP2ServerTransport.Posix {
 
     /// The validated peer certificate chain from the mTLS handshake. This is only available when using a custom verification callback.
     @available(gRPCSwiftNIOTransport 2.2, *)
-    public var peerValidatedCertificateChain: X509.ValidatedCertificateChain?
+    public var peerCertificateChain: X509.ValidatedCertificateChain?
 
     public init() {
     }

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -197,6 +197,12 @@ extension HTTP2ServerTransport {
           }
         } catch {}
 
+        do {
+          if let peerValidatedCertificateChain = try await channel.nioSSL_peerValidatedCertificateChain().get() {
+            context.peerValidatedCertificateChain = try? peerValidatedCertificateChain.usingX509Certificates()
+          }
+        } catch {}
+
         return context
       }
     }
@@ -222,6 +228,10 @@ extension HTTP2ServerTransport.Posix {
   public struct Context: ServerContext.TransportSpecific {
     /// The peer certificate (if any) from the mTLS handshake
     public var peerCertificate: Certificate?
+
+    /// The validated peer certificate chain from the mTLS handshake. This is only available when using a custom verification callback.
+    @available(gRPCSwiftNIOTransport 2.2, *)
+    public var peerValidatedCertificateChain: X509.ValidatedCertificateChain?
 
     public init() {
     }

--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -198,8 +198,11 @@ extension HTTP2ServerTransport {
         } catch {}
 
         do {
-          if let peerValidatedCertificateChain = try await channel.nioSSL_peerValidatedCertificateChain().get() {
-            context.peerValidatedCertificateChain = try? peerValidatedCertificateChain.usingX509Certificates()
+          if let peerValidatedCertificateChain =
+            try await channel.nioSSL_peerValidatedCertificateChain().get()
+          {
+            context.peerValidatedCertificateChain =
+              try? peerValidatedCertificateChain.usingX509Certificates()
           }
         } catch {}
 

--- a/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
@@ -1,14 +1,16 @@
-internal import X509
 internal import NIOSSL
 internal import SwiftASN1
+internal import X509
 
 @available(gRPCSwiftNIOTransport 2.2, *)
 extension NIOSSL.ValidatedCertificateChain {
-    // The precondition holds because the `NIOSSL.ValidatedCertificateChain` always contains one `NIOSSLCertificate`.
-    func usingX509Certificates() throws -> X509.ValidatedCertificateChain {
-        return .init(uncheckedCertificateChain: try self.map {
-            let derBytes = try $0.toDERBytes()
-            return try Certificate(derEncoded: derBytes)
-        })
-    }
+  // The precondition holds because the `NIOSSL.ValidatedCertificateChain` always contains one `NIOSSLCertificate`.
+  func usingX509Certificates() throws -> X509.ValidatedCertificateChain {
+    return .init(
+      uncheckedCertificateChain: try self.map {
+        let derBytes = try $0.toDERBytes()
+        return try Certificate(derEncoded: derBytes)
+      }
+    )
+  }
 }

--- a/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 internal import NIOSSL
 internal import SwiftASN1
 internal import X509

--- a/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
@@ -1,0 +1,14 @@
+internal import X509
+internal import NIOSSL
+internal import SwiftASN1
+
+@available(gRPCSwiftNIOTransport 2.2, *)
+extension NIOSSL.ValidatedCertificateChain {
+    // The precondition holds because the `NIOSSL.ValidatedCertificateChain` always contains one `NIOSSLCertificate`.
+    func usingX509Certificates() throws -> X509.ValidatedCertificateChain {
+        return .init(uncheckedCertificateChain: try self.map {
+            let derBytes = try $0.toDERBytes()
+            return try Certificate(derEncoded: derBytes)
+        })
+    }
+}

--- a/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/ValidatedCertificateChain.swift
@@ -19,14 +19,13 @@ internal import SwiftASN1
 internal import X509
 
 @available(gRPCSwiftNIOTransport 2.2, *)
-extension NIOSSL.ValidatedCertificateChain {
+extension X509.ValidatedCertificateChain {
   // The precondition holds because the `NIOSSL.ValidatedCertificateChain` always contains one `NIOSSLCertificate`.
-  func usingX509Certificates() throws -> X509.ValidatedCertificateChain {
-    return .init(
-      uncheckedCertificateChain: try self.map {
-        let derBytes = try $0.toDERBytes()
-        return try Certificate(derEncoded: derBytes)
-      }
-    )
+  init(_ chain: NIOSSL.ValidatedCertificateChain) throws {
+    let certs = try chain.map {
+      let derBytes = try $0.toDERBytes()
+      return try Certificate(derEncoded: derBytes)
+    }
+    self.init(uncheckedCertificateChain: certs)
   }
 }

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -65,9 +65,11 @@ struct HTTP2TransportTLSEnabledTests {
   @available(gRPCSwiftNIOTransport 2.0, *)
   final class TransportSpecificInterceptor: ServerInterceptor {
     let clientCert: [UInt8]
+
     init(_ clientCert: [UInt8]) {
       self.clientCert = clientCert
     }
+
     func intercept<Input, Output>(
       request: GRPCCore.StreamingServerRequest<Input>,
       context: GRPCCore.ServerContext,
@@ -349,9 +351,11 @@ struct HTTP2TransportTLSEnabledTests {
   @available(gRPCSwiftNIOTransport 2.2, *)
   final class ValidatedCertificateChainInterceptor: ServerInterceptor {
     let expectedCertificateChain: [Certificate]
+
     init(_ expectedCertificateChain: [Certificate]) {
       self.expectedCertificateChain = expectedCertificateChain
     }
+
     func intercept<Input, Output>(
       request: GRPCCore.StreamingServerRequest<Input>,
       context: GRPCCore.ServerContext,
@@ -365,21 +369,21 @@ struct HTTP2TransportTLSEnabledTests {
         transportSpecific as? HTTP2ServerTransport.Posix.Context
       )
 
-      let peerValidatedCertificateChain = try #require(
-        transportSpecificAsPosixContext.peerValidatedCertificateChain
+      let peerCertificateChain = try #require(
+        transportSpecificAsPosixContext.peerCertificateChain
       )
       // The validated certifiacte chain always contains at least one element.
-      #expect(!peerValidatedCertificateChain.isEmpty)
+      #expect(!peerCertificateChain.isEmpty)
 
       // And these chains should have the same length.
-      #expect(peerValidatedCertificateChain.count == self.expectedCertificateChain.count)
-      for (lhs, rhs) in zip(peerValidatedCertificateChain, self.expectedCertificateChain) {
+      #expect(peerCertificateChain.count == self.expectedCertificateChain.count)
+      for (lhs, rhs) in zip(peerCertificateChain, self.expectedCertificateChain) {
         #expect(lhs == rhs)
       }
 
       // leaf and root should match the first and last element of the expected chain.
-      #expect(peerValidatedCertificateChain.leaf == self.expectedCertificateChain.first!)
-      #expect(peerValidatedCertificateChain.root == self.expectedCertificateChain.last!)
+      #expect(peerCertificateChain.leaf == self.expectedCertificateChain.first!)
+      #expect(peerCertificateChain.root == self.expectedCertificateChain.last!)
 
       return try await next(request, context)
     }
@@ -389,7 +393,7 @@ struct HTTP2TransportTLSEnabledTests {
     "When using a custom certificate callback the validated certifiate chain of the peer is available."
   )
   @available(gRPCSwiftNIOTransport 2.2, *)
-  func testRPC_mTLS_peerValidatedCertificateChain() async throws {
+  func testRPC_mTLS_peerCertificateChain() async throws {
     // Create a new certificate chain that has 4 certificate/key pairs: root, intermediate, client, server
     let certificateChain = try CertificateChain()
     let expectedCertificateChain = [certificateChain.client.certificate]

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -346,6 +346,85 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
+  @available(gRPCSwiftNIOTransport 2.2, *)
+  final class ValidatedCertificateChainInterceptor: ServerInterceptor {
+    let expectedCertificateChain: [Certificate]
+    init(_ expectedCertificateChain: [Certificate]) {
+      self.expectedCertificateChain = expectedCertificateChain
+    }
+    func intercept<Input, Output>(
+      request: GRPCCore.StreamingServerRequest<Input>,
+      context: GRPCCore.ServerContext,
+      next:
+        @Sendable (GRPCCore.StreamingServerRequest<Input>, GRPCCore.ServerContext) async throws
+        -> GRPCCore.StreamingServerResponse<Output>
+    ) async throws -> GRPCCore.StreamingServerResponse<Output>
+    where Input: Sendable, Output: Sendable {
+      let transportSpecific = context.transportSpecific
+      let transportSpecificAsPosixContext = try #require(
+        transportSpecific as? HTTP2ServerTransport.Posix.Context
+      )
+
+      let peerValidatedCertificateChain = try #require(transportSpecificAsPosixContext.peerValidatedCertificateChain)
+      // The validated certifiacte chain always contains at least one element.
+      #expect(!peerValidatedCertificateChain.isEmpty)
+
+      // And these chains should have the same length.
+      #expect(peerValidatedCertificateChain.count == self.expectedCertificateChain.count)
+      for (lhs, rhs) in zip(peerValidatedCertificateChain, self.expectedCertificateChain) {
+        #expect(lhs == rhs)
+      }
+
+      // leaf and root should match the first and last element of the expected chain.
+      #expect(peerValidatedCertificateChain.leaf == self.expectedCertificateChain.first!)
+      #expect(peerValidatedCertificateChain.root == self.expectedCertificateChain.last!)
+
+      return try await next(request, context)
+    }
+  }
+
+  @Test("When using a custom certificate callback the validated certifiate chain of the peer is available.")
+  @available(gRPCSwiftNIOTransport 2.2, *)
+  func testRPC_mTLS_peerValidatedCertificateChain() async throws {
+    // Create a new certificate chain that has 4 certificate/key pairs: root, intermediate, client, server
+    let certificateChain = try CertificateChain()
+    let expectedCertificateChain = [certificateChain.client.certificate]
+    let filePaths = try certificateChain.writeToTemp()
+
+    // Client and server configurations.
+    let clientConfig = self.makeMTLSClientConfig(
+      certificatePath: filePaths.clientCert,
+      keyPath: filePaths.clientKey,
+      trustRootsPath: filePaths.trustRoots,
+      serverHostname: CertificateChain.serverName
+    )
+    let serverConfig = self.makeMTLSServerConfigWithCallback(
+      certificatePath: filePaths.serverCert,
+      keyPath: filePaths.serverKey,
+      trustRootsPath: filePaths.trustRoots
+    ) { certificates, promise in
+      let presentedCertificates = certificates.map {
+        try! Certificate(derEncoded: $0.toDERBytes())
+      }
+      #expect([certificateChain.client.certificate] == presentedCertificates)
+      // "Verify" the chain and set the certificate.
+      promise.succeed(
+        .certificateVerified(VerificationMetadata(ValidatedCertificateChain(certificates)))
+      )
+    }
+
+    // Run the test. The interceptor checks that we can query the expected certificate chain.
+    try await self.withClientAndServer(
+      clientConfig: clientConfig,
+      serverConfig: serverConfig,
+      interceptors: [ValidatedCertificateChainInterceptor(expectedCertificateChain)]
+    ) { control in
+      await #expect(throws: Never.self) {
+        try await self.executeUnaryRPC(control: control)
+      }
+    }
+  }
+
   @Test(
     "Error is surfaced when client fails server verification",
     arguments: TransportKind.clientsWithTLS,

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -365,7 +365,9 @@ struct HTTP2TransportTLSEnabledTests {
         transportSpecific as? HTTP2ServerTransport.Posix.Context
       )
 
-      let peerValidatedCertificateChain = try #require(transportSpecificAsPosixContext.peerValidatedCertificateChain)
+      let peerValidatedCertificateChain = try #require(
+        transportSpecificAsPosixContext.peerValidatedCertificateChain
+      )
       // The validated certifiacte chain always contains at least one element.
       #expect(!peerValidatedCertificateChain.isEmpty)
 
@@ -383,7 +385,9 @@ struct HTTP2TransportTLSEnabledTests {
     }
   }
 
-  @Test("When using a custom certificate callback the validated certifiate chain of the peer is available.")
+  @Test(
+    "When using a custom certificate callback the validated certifiate chain of the peer is available."
+  )
   @available(gRPCSwiftNIOTransport 2.2, *)
   func testRPC_mTLS_peerValidatedCertificateChain() async throws {
     // Create a new certificate chain that has 4 certificate/key pairs: root, intermediate, client, server


### PR DESCRIPTION
### Motivation:

The peer certificate chain can contain relevant information in some mTLS scenarios. NIO SSL only exposes the validated certificate chain when using custom verification callbacks. Now that this configuration option is available here, we can expose this property as well.

### Modifications:

Make the property available and expose it as a validated certificate chain type from swift-certificates. Add tests to confirm the implementation.

### Result:

The validated certificate chain is available when using mTLS with a custom certificate validation callback.