### PR TITLE
Add missing test import

### DIFF
--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/Connection+Equatable.swift
@@ -16,6 +16,7 @@
 
 import GRPCCore
 import GRPCNIOTransportCore
+import NIOHTTP2
 
 // Equatable conformance for these types is 'best effort', this is sufficient for testing but not
 // for general use.


### PR DESCRIPTION
Motivation:

Nightly builds fails to compile because an extension defined in tests relies on a missing import.

Modifications:

Add the missing import

Result:

Nightly CI passes