### PR TITLE
Fix crash when deiniting server without starting

### DIFF
--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportRegressionTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportRegressionTests.swift
@@ -138,4 +138,16 @@ struct HTTP2TransportRegressionTests {
       }
     }
   }
+
+  @Test
+  @available(gRPCSwiftNIOTransport 2.2, *)
+  func testNeverStartingServerDoesNotCrash() async throws {
+    let transport = HTTP2ServerTransport.Posix(
+      address: .ipv4(host: "0.0.0.0", port: 5678),
+      transportSecurity: .plaintext
+    )
+
+    // This should not crash
+    _ = GRPCServer(transport: transport, services: [])
+  }
 }


### PR DESCRIPTION
If a GRPCServer is created using the NIO transport, and it's immediately discarded without starting it, the NIO transport will crash because the listening address promise won't be fulfilled/will be leaked. This PR makes sure the promise is failed on `deinit`.