### PR TITLE
Emit requiresNameResolution on connect failure backoff

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/LoadBalancers/Subchannel.swift
@@ -309,6 +309,9 @@ extension Subchannel {
           .transientFailure(cause: error)
         )
       )
+      // Trigger name re-resolution so the resolver can fetch fresh addresses.
+      // Matches gRPC-Go behavior (clientconn.go: resolveNow after tryAllAddrs fails).
+      self.event.continuation.yield(.requiresNameResolution)
       group.addTask {
         do {
           try await Task.sleep(for: duration, tolerance: .zero)


### PR DESCRIPTION
## Summary

When all addresses in an endpoint have been tried and `Subchannel` enters backoff, it emits `.transientFailure` but does **not** emit `.requiresNameResolution`. This means pull-based name resolvers (like CloudMap service discovery) never get their `next()` called to fetch fresh addresses — the subchannel retries the same stale IPs with exponential backoff indefinitely.

This PR adds a single `.requiresNameResolution` yield after the `.transientFailure` emission in `handleConnectFailedEvent`'s `.backoff` case, matching gRPC-Go's behavior:

- In gRPC-Go's `clientconn.go` (~line 1468), `resolveNow()` is explicitly called after `tryAllAddrs()` fails
- The `pick_first` balancer comments: *"We don't need to request re-resolution since the SubConn already does that before reporting TRANSIENT_FAILURE."* ([source](https://github.com/grpc/grpc-go/blob/master/balancer/pickfirst/pickfirst.go#L859))

Note that `handleConnectionClosedEvent` already emits `.requiresNameResolution` for unclean connection closes (line 357), and `handleGoingAwayEvent` does the same for GOAWAY frames (line 340). The connect-failure backoff path is the only code path missing this signal.

## Motivation

In our deployment, ECS tasks are replaced ~30 times/day with new IPs. The gRPC channel caches old IPs from CloudMap and retries them with exponential backoff — but never triggers re-resolution to fetch fresh IPs. This causes ~5 minutes of unavailability after each deployment until the Lambda runtime is recycled.

## Changes

- **`Subchannel.swift`**: Added `self.event.continuation.yield(.requiresNameResolution)` after the `.transientFailure` emission in the `.backoff` case of `handleConnectFailedEvent`

## Test plan

- Verified existing tests pass
- Deployed with this fix in production — health checks recover within seconds after service redeployment instead of ~5 minutes