### PR TITLE
Fix warning on nightly swift

### DIFF
--- a/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/DiscardingTaskGroup+CancellableHandle.swift
@@ -65,15 +65,15 @@ extension DiscardingTaskGroup {
 @available(gRPCSwiftNIOTransport 2.0, *)
 struct CancellableTaskHandle: Sendable {
   @usableFromInline
-  private(set) var continuation: AsyncStream<Void>.Continuation
+  var _continuation: AsyncStream<Void>.Continuation
 
   @inlinable
   init(continuation: AsyncStream<Void>.Continuation) {
-    self.continuation = continuation
+    self._continuation = continuation
   }
 
   @inlinable
   func cancel() {
-    self.continuation.finish()
+    self._continuation.finish()
   }
 }


### PR DESCRIPTION
Motivation:

The nightly swift build emits a warning about using a `@usableFromInline private(set)` from an `@inlinable` function.

Modifications:

- Remove the `private(set)` so that the setter is internal

Result:

No warnings