### PR TITLE
Write end stream in clientClosedServerClosed if not yet written

### DIFF
--- a/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCNIOTransportCore/GRPCStreamStateMachine.swift
@@ -827,8 +827,16 @@ struct GRPCStreamStateMachine {
     case .clientClosedServerClosed(var state):
       switch self.configuration {
       case .client:
-        // No point in sending any more requests if the server is closed.
-        action = .noMoreMessages
+        if state.hasSentEndStream {
+          action = .noMoreMessages
+        } else {
+          // No point in sending any more requests if the server is closed,
+          // but we still need to send END_STREAM to properly half-close.
+          self.state = ._modifying
+          state.hasSentEndStream = true
+          self.state = .clientClosedServerClosed(state)
+          action = .sendFrame(frame: ByteBuffer(), endStream: true, promise: nil)
+        }
 
       case .server:
         self.state = ._modifying

--- a/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -1038,6 +1038,118 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     try channel.closeFuture.wait()
   }
 
+  func testTrailersOnlyResponseThenHalfCloseSendsEndStream() throws {
+    // When the server sends a valid trailers-only response while the client hasn't half-closed
+    // yet, the subsequent half-close must still send an END_STREAM frame so the HTTP/2 stream
+    // can fully close.
+    let handler = GRPCClientStreamHandler(
+      methodDescriptor: .testTest,
+      scheme: .http,
+      authority: nil,
+      outboundEncoding: .none,
+      acceptedEncodings: [],
+      maxPayloadSize: 100,
+      skipStateMachineAssertions: true
+    )
+
+    let channel = EmbeddedChannel(handler: handler)
+
+    // Send client's initial metadata to open the stream.
+    try channel.writeOutbound(RPCRequestPart<GRPCNIOTransportBytes>.metadata([:]))
+    _ = try channel.assertReadHeadersOutbound()
+
+    // Server sends a valid trailers-only response (headers with grpc-status and endStream).
+    let serverTrailersOnly: HPACKHeaders = [
+      ":status": "200",
+      "content-type": "application/grpc",
+      "grpc-status": String(Status.Code.aborted.rawValue),
+      "grpc-message": "rejected",
+    ]
+    try channel.writeInbound(
+      HTTP2Frame.FramePayload.headers(.init(headers: serverTrailersOnly, endStream: true))
+    )
+
+    // Should receive the status and metadata.
+    XCTAssertEqual(
+      try channel.readInbound(as: RPCResponsePart<GRPCNIOTransportBytes>.self),
+      .status(
+        Status(code: .aborted, message: "rejected"),
+        [":status": "200", "content-type": "application/grpc"]
+      )
+    )
+
+    // Half-close the outbound end (triggered by finishing the client's writer).
+    XCTAssertNoThrow(channel.close(mode: .output, promise: nil))
+
+    // The handler must send an empty DATA frame with END_STREAM so the HTTP/2
+    // stream can fully close.
+    let endStreamFrame = try channel.assertReadDataOutbound()
+    XCTAssertEqual(endStreamFrame.data, .byteBuffer(.init()))
+    XCTAssertTrue(endStreamFrame.endStream)
+
+    // No more outbound frames.
+    channel.flush()
+    XCTAssertNil(try channel.readOutbound(as: HTTP2Frame.FramePayload.self))
+  }
+
+  func testServerTrailersThenHalfCloseSendsEndStream() throws {
+    // When the server closes before the client, the clients subsequent half-close must still
+    // write an END_STREAM frame into the channel to close the HTTP/2 stream.
+    let handler = GRPCClientStreamHandler(
+      methodDescriptor: .testTest,
+      scheme: .http,
+      authority: nil,
+      outboundEncoding: .none,
+      acceptedEncodings: [],
+      maxPayloadSize: 100,
+      skipStateMachineAssertions: true
+    )
+
+    let channel = EmbeddedChannel(handler: handler)
+
+    // Send client's initial metadata.
+    try channel.writeOutbound(RPCRequestPart<GRPCNIOTransportBytes>.metadata([:]))
+    _ = try channel.assertReadHeadersOutbound()
+
+    // Server sends initial metadata (no endStream).
+    let serverInitialMetadata: HPACKHeaders = [
+      ":status": "200",
+      "content-type": "application/grpc",
+    ]
+    try channel.writeInbound(
+      HTTP2Frame.FramePayload.headers(.init(headers: serverInitialMetadata))
+    )
+    XCTAssertEqual(
+      try channel.readInbound(as: RPCResponsePart<GRPCNIOTransportBytes>.self),
+      .metadata(Metadata(headers: serverInitialMetadata))
+    )
+
+    // Server sends trailers with endStream.
+    let serverTrailers: HPACKHeaders = [
+      "grpc-status": String(Status.Code.ok.rawValue)
+    ]
+    try channel.writeInbound(
+      HTTP2Frame.FramePayload.headers(.init(headers: serverTrailers, endStream: true))
+    )
+    XCTAssertEqual(
+      try channel.readInbound(as: RPCResponsePart<GRPCNIOTransportBytes>.self),
+      .status(.init(code: .ok, message: ""), [:])
+    )
+
+    // Half-close the outbound end.
+    XCTAssertNoThrow(channel.close(mode: .output, promise: nil))
+
+    // The handler must send an empty DATA frame with END_STREAM so the HTTP/2
+    // stream can fully close.
+    let endStreamFrame = try channel.assertReadDataOutbound()
+    XCTAssertEqual(endStreamFrame.data, .byteBuffer(.init()))
+    XCTAssertTrue(endStreamFrame.endStream)
+
+    // No more outbound frames.
+    channel.flush()
+    XCTAssertNil(try channel.readOutbound(as: HTTP2Frame.FramePayload.self))
+  }
+
   func testWritabilityChangedWhileClientIdleDoesNotCrash() throws {
     // Regression test: channelWritabilityChanged must not call _flush when
     // there is no pending flush, because the state machine is still in an idle

--- a/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/GRPCStreamStateMachineTests.swift
@@ -944,7 +944,11 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     XCTAssertNoThrow(try stateMachine.closeOutbound())
 
     // Even though we have enqueued a message, don't send it, because the server
-    // is closed.
+    // is closed. But we still need to send END_STREAM.
+    XCTAssertEqual(
+      try stateMachine.nextOutboundFrame(),
+      .sendFrame(frame: ByteBuffer(), endStream: true, promise: nil)
+    )
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
   }
 
@@ -1235,6 +1239,12 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       )
     )
 
+    // Client closed but END_STREAM wasn't flushed before the server closed,
+    // so it must be sent now.
+    XCTAssertEqual(
+      try stateMachine.nextOutboundFrame(),
+      .sendFrame(frame: ByteBuffer(), endStream: true, promise: nil)
+    )
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
     XCTAssertEqual(stateMachine.nextInboundMessage(), .noMoreMessages)
   }
@@ -1424,6 +1434,12 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       )
     )
 
+    // Client closed but END_STREAM wasn't flushed before the server closed,
+    // so it must be sent now.
+    XCTAssertEqual(
+      try stateMachine.nextOutboundFrame(),
+      .sendFrame(frame: ByteBuffer(), endStream: true, promise: nil)
+    )
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
     XCTAssertEqual(stateMachine.nextInboundMessage(), .noMoreMessages)
   }
@@ -1525,6 +1541,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     try action.assertDoNothing()
     let next = stateMachine.nextInboundMessage()
     try next.assertNoMoreMessages()
+    // END_STREAM hasn't been flushed yet, so the first call emits it.
+    let endStream = try stateMachine.nextOutboundFrame()
+    XCTAssertEqual(endStream, .sendFrame(frame: ByteBuffer(), endStream: true, promise: nil))
     let next2 = try stateMachine.nextOutboundFrame()
     try next2.assertNoMoreMessages()
   }


### PR DESCRIPTION
Motivation:

There's a path through the client stream state machine where if the server has sent end stream and the client has sent an outbound close, then the client's end stream won't be written. This results in the client stream channel not being closed (as the http/2 layer doesn't yet know the client has closed).

This happens because end stream is emitted based on calls to nextOutboundFrame which on this path always returned 'noMoreMessages'. It should emit a single empty message with end stream set if end stream hasn't yet been written.

Modifications:

- If end stream hasn't been set, emit an empty frame with end stream set

Result:

The stream channel gets closed