### PR TITLE
Defer buffered read delivery to avoid re-entrant SETTINGS loss in tests

### DIFF
--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/BufferInboundUntilFlush.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/BufferInboundUntilFlush.swift
@@ -76,7 +76,7 @@ final class BufferInboundUntilFlush: ChannelDuplexHandler {
       // would decode the server's SETTINGS frame and the multiplexer would forward
       // it inbound as an 'HTTP2Frame'. The 'ClientConnectionHandler' would never see the
       // initial SETTINGS frame (it hasn't been added to the pipeline yet) and would never
-      // emit '.ready', and the connection would hang.
+      // emit '.ready', and the connection would be wedged.
       //
       // Deferring by one tick allows the current tick to finish configuring the
       // pipeline. On the next tick the buffered bytes are delivered through the

--- a/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/BufferInboundUntilFlush.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/Test Utilities/BufferInboundUntilFlush.swift
@@ -40,6 +40,15 @@ final class BufferInboundUntilFlush: ChannelDuplexHandler {
     self.isBuffering = true
   }
 
+  private func unbuffer(context: ChannelHandlerContext) {
+    self.isBuffering = false
+    if let buffered = self.accumulated.take() {
+      let wrapped = self.wrapInboundOut(buffered)
+      context.fireChannelRead(wrapped)
+      context.fireChannelReadComplete()
+    }
+  }
+
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     if self.isBuffering {
       let buffer = self.unwrapInboundIn(data)
@@ -49,11 +58,31 @@ final class BufferInboundUntilFlush: ChannelDuplexHandler {
     }
   }
 
+  func channelReadComplete(context: ChannelHandlerContext) {
+    if !self.isBuffering {
+      context.fireChannelReadComplete()
+    }
+  }
+
   func flush(context: ChannelHandlerContext) {
     if self.isBuffering {
-      self.isBuffering = false
-      if let buffered = self.accumulated.take() {
-        context.fireChannelRead(self.wrapInboundOut(buffered))
+      // Defer unbuffering to the next event loop tick.
+      //
+      // This flush originates from the NIOHTTP2Handler writing its connection preface
+      // in 'handlerAdded'. At this point 'configureGRPCClientPipeline' has not finished so the
+      // 'ClientConnectionHandler' has not been added to the pipeline yet.
+      //
+      // If the handler delivered the buffered bytes synchronously the 'NIOHTTP2Handler'
+      // would decode the server's SETTINGS frame and the multiplexer would forward
+      // it inbound as an 'HTTP2Frame'. The 'ClientConnectionHandler' would never see the
+      // initial SETTINGS frame (it hasn't been added to the pipeline yet) and would never
+      // emit '.ready', and the connection would hang.
+      //
+      // Deferring by one tick allows the current tick to finish configuring the
+      // pipeline. On the next tick the buffered bytes are delivered through the
+      // fully configured pipeline.
+      context.eventLoop.assumeIsolated().execute {
+        self.unbuffer(context: context)
       }
     }
 


### PR DESCRIPTION
Motivation:

Tests using the WrappedChannel client transport add a BufferInboundUntilFlush handler to catch the server's HTTP/2 connection preface before the pipeline is configured. The handler releases the buffered bytes on the first outbound flush, which is triggeded by the NIOHTTP2Handler writing the client connection preface in handlerAdded.

The old code delivered the buffered bytes synchronously inside the flush handler. This caused a re-entrant channelRead into the NIOHTTP2Handler while still inside its writeAndFlushPreamble. The NIOHTTP2Handler decoded the server's SETTINGS frame and the multiplexer forwarded it as an HTTP2Frame to the parent channel pipeline.

But at this point configureAsyncHTTP2Pipeline had not yet returned, so the ClientConnectionHandler had not been added to the pipeline. The SETTINGS frame went to the tail and was silently dropped.

This means the ClientConnectionHandler never saw the first SETTINGS frame, so it never emitted '.ready'. The WrappedChannel state machine queued stream requests waiting for '.ready' indefinitely, causing the connection to hang.

Modifications:

- Schedule unbuffering on the next event loop tick so that the pipeline is fully configured before unbuffering data.
- Swallow channelReadComplete while buffering to keep read and read-complete events paired.

Result:

Fewer flaky tests.