### PR TITLE
Add flush coalescing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,7 @@ let dependencies: [Package.Dependency] = [
 
 // This adds some build settings which allow us to map "@available(gRPCSwiftNIOTransport 2.x, *)" to
 // the appropriate OS platforms.
-let nextMinorVersion = 6
+let nextMinorVersion = 8
 let availabilitySettings: [SwiftSetting] = (0 ... nextMinorVersion).map { minor in
   let name = "gRPCSwiftNIOTransport"
   let version = "2.\(minor)"

--- a/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Client/HTTP2ClientTransport.swift
@@ -92,15 +92,38 @@ extension HTTP2ClientTransport.Config {
     /// See also: gRFC A8: Client-side Keepalive.
     public var keepalive: Keepalive?
 
+    /// Configuration for flush coalescing.
+    ///
+    /// Flush coalescing delays flushing outbound writes on the HTTP/2 connection to batch them
+    /// together, reducing the number of syscalls. For high-traffic workloads this typically
+    /// reduces both CPU usage and latency as fewer, larger writes are more efficient. For
+    /// low-traffic workloads the delay may add a small amount of latency (bounded by
+    /// ``FlushCoalescing/maxFlushDelay``) as there are fewer writes to coalesce.
+    ///
+    /// If `nil`, flush coalescing is disabled and each flush is passed through immediately.
+    @available(gRPCSwiftNIOTransport 2.8, *)
+    public var flushCoalescing: FlushCoalescing?
+
     /// Creates a connection configuration.
+    ///
+    /// New properties and features added to `Connection` are disabled by default when using
+    /// this initializer. Use ``defaults`` to get a configuration with all features enabled
+    /// at their default values.
     public init(maxIdleTime: Duration, keepalive: Keepalive?) {
-      self.maxIdleTime = maxIdleTime
-      self.keepalive = keepalive
+      self.init(maxIdleTime: maxIdleTime, keepalive: keepalive, flushCoalescing: nil)
     }
 
-    /// Default values, a 30 minute max idle time and no keepalive.
+    @available(gRPCSwiftNIOTransport 2.8, *)
+    private init(maxIdleTime: Duration, keepalive: Keepalive?, flushCoalescing: FlushCoalescing?) {
+      self.maxIdleTime = maxIdleTime
+      self.keepalive = keepalive
+      self.flushCoalescing = flushCoalescing
+    }
+
+    /// Default values, a 30 minute max idle time, no keepalive, and flush coalescing enabled
+    /// with default values.
     public static var defaults: Self {
-      Self(maxIdleTime: .seconds(30 * 60), keepalive: nil)
+      Self(maxIdleTime: .seconds(30 * 60), keepalive: nil, flushCoalescing: .defaults)
     }
   }
 
@@ -194,6 +217,50 @@ extension HTTP2ClientTransport.Config {
     /// Default values; no callbacks are set.
     public static var defaults: Self {
       Self(onCreateTCPConnection: nil, onCreateHTTP2Stream: nil)
+    }
+  }
+}
+
+@available(gRPCSwiftNIOTransport 2.0, *)
+extension HTTP2ClientTransport.Config.Connection {
+  /// Flush coalescing batches together writes to reduce the overhead from syscalls.
+  ///
+  /// A channel handler intercepts flush events on the HTTP/2 connection channel and delays them
+  /// until one of the following conditions is met:
+  /// 1. ``maxFlushDelay`` has elapsed since a flush was first requested,
+  /// 2. At least ``maxBytes`` bytes have been written since the previous flush, or
+  /// 3. The channel becomes unwritable (i.e. the outbound buffer has hit the high-water mark).
+  ///
+  /// This means that under high load, writes naturally accumulate and are flushed together in
+  /// fewer, larger batches. This reduces per-write overhead and typically improves both throughput
+  /// and latency.
+  ///
+  /// Under low load there are fewer writes to coalesce so flushes are typically delayed by
+  /// up to ``maxFlushDelay``. If your workload is latency-sensitive and low-throughput then
+  /// disabling coalescing (by setting
+  /// ``HTTP2ServerTransport/Config/Connection/flushCoalescing`` to `nil`) may be preferable.
+  ///
+  /// The default values (see ``defaults``) aim to provide a good balance for most workloads
+  /// without adding significant latency.
+  @available(gRPCSwiftNIOTransport 2.8, *)
+  public struct FlushCoalescing: Sendable, Hashable {
+    /// The maximum delay between a flush being requested and it being performed.
+    public var maxFlushDelay: Duration
+
+    /// The number of bytes to buffer before a flush is emitted, regardless of the delay.
+    public var maxBytes: Int
+
+    /// Creates a new flush coalescing configuration.
+    ///
+    /// - SeeAlso: ``defaults``.
+    public init(maxFlushDelay: Duration, maxBytes: Int) {
+      self.maxFlushDelay = maxFlushDelay
+      self.maxBytes = maxBytes
+    }
+
+    /// Default values. The max flush delay is 100μs and the max bytes is 64KiB.
+    public static var defaults: Self {
+      Self(maxFlushDelay: .microseconds(100), maxBytes: 64 * 1024)
     }
   }
 }

--- a/Sources/GRPCNIOTransportCore/Internal/FlushCoalescingHandler.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/FlushCoalescingHandler.swift
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOCore
+
+internal final class FlushCoalescingHandler: ChannelDuplexHandler {
+  internal typealias InboundIn = ByteBuffer
+  internal typealias InboundOut = ByteBuffer
+  internal typealias OutboundIn = ByteBuffer
+  internal typealias OutboundOut = ByteBuffer
+
+  /// Max delay between a flush being requested and it being delivered.
+  private let maxFlushDelay: TimeAmount
+  /// The number of bytes to write before a flush is emitted.
+  private let maxBytes: Int
+
+  struct Pending {
+    /// Number of bytes written without a flush.
+    var bytes: Int
+    /// Number of flushes requested but not yet delivered.
+    var flushes: Int
+
+    mutating func reset() {
+      self.bytes = 0
+      self.flushes = 0
+    }
+  }
+
+  /// The number of pending flushes and bytes.
+  private var pending: Pending
+
+  /// Callback to trigger a flush.
+  private var flushCallback: NIOScheduledCallback?
+  /// Context; nil'd out when the handler is removed from the pipeline.
+  private var context: ChannelHandlerContext?
+
+  internal init(maxFlushDelay: TimeAmount, maxBytes: Int) {
+    self.pending = Pending(bytes: 0, flushes: 0)
+    self.maxFlushDelay = maxFlushDelay
+    self.maxBytes = maxBytes
+    self.flushCallback = nil
+  }
+
+  internal func handlerAdded(context: ChannelHandlerContext) {
+    self.context = context
+  }
+
+  internal func handlerRemoved(context: ChannelHandlerContext) {
+    self.context = nil
+    self.flushCallback?.cancel()
+    self.flushCallback = nil
+  }
+
+  internal func channelWritabilityChanged(context: ChannelHandlerContext) {
+    let isWritable = context.channel.isWritable
+
+    if !isWritable && self.pending.flushes > 0 {
+      // Stopped being writable: flush out any bytes.
+      self.flushNow(context: context)
+    }
+
+    context.fireChannelWritabilityChanged()
+  }
+
+  internal func write(
+    context: ChannelHandlerContext,
+    data: NIOAny,
+    promise: EventLoopPromise<Void>?
+  ) {
+    let buffer = self.unwrapOutboundIn(data)
+    self.pending.bytes += buffer.readableBytes
+
+    context.write(data, promise: promise)
+
+    guard self.pending.flushes > 0 else { return }
+
+    if self.pending.bytes >= self.maxBytes {
+      self.flushNow(context: context)
+    } else {
+      self.scheduleCallbackIfNecessary(context: context)
+    }
+  }
+
+  internal func flush(context: ChannelHandlerContext) {
+    self.pending.flushes += 1
+
+    if self.pending.bytes >= self.maxBytes {
+      self.flushNow(context: context)
+    } else {
+      self.scheduleCallbackIfNecessary(context: context)
+    }
+  }
+
+  internal func close(
+    context: ChannelHandlerContext,
+    mode: CloseMode,
+    promise: EventLoopPromise<Void>?
+  ) {
+    if self.pending.flushes > 0 {
+      self.flushNow(context: context)
+    }
+
+    context.close(mode: mode, promise: promise)
+  }
+
+  private func scheduleCallbackIfNecessary(context: ChannelHandlerContext) {
+    guard self.flushCallback == nil else { return }
+
+    // Can fail if the event-loop has shut down.
+    self.flushCallback = try? context.eventLoop.scheduleCallback(
+      in: self.maxFlushDelay,
+      handler: FlushCallbackHandler(NIOLoopBound(self, eventLoop: context.eventLoop))
+    )
+  }
+
+  private func flushNow(context: ChannelHandlerContext) {
+    self.flushCallback?.cancel()
+    self.flushCallback = nil
+    self.pending.reset()
+    context.flush()
+  }
+
+  private func handleFlushCallback() {
+    if let context = self.context {
+      self.flushNow(context: context)
+    }
+  }
+
+  struct FlushCallbackHandler: Sendable, NIOScheduledCallbackHandler {
+    let handler: NIOLoopBound<FlushCoalescingHandler>
+
+    init(_ handler: NIOLoopBound<FlushCoalescingHandler>) {
+      self.handler = handler
+    }
+
+    func handleScheduledCallback(eventLoop: some EventLoop) {
+      if handler.eventLoop === eventLoop {
+        handler.value.handleFlushCallback()
+      } else {
+        handler.eventLoop.execute {
+          handler.value.handleFlushCallback()
+        }
+      }
+    }
+  }
+}

--- a/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCNIOTransportCore/Internal/NIOChannelPipeline+GRPC.swift
@@ -61,6 +61,14 @@ extension ChannelPipeline.SynchronousOperations {
     )
     try self.addHandler(flushNotificationHandler)
 
+    if let flushCoalescing = connectionConfig.flushCoalescing {
+      let coalescing = FlushCoalescingHandler(
+        maxFlushDelay: TimeAmount(flushCoalescing.maxFlushDelay),
+        maxBytes: flushCoalescing.maxBytes
+      )
+      try self.addHandler(coalescing)
+    }
+
     let clampedTargetWindowSize = self.clampTargetWindowSize(http2Config.targetWindowSize)
     let clampedMaxFrameSize = self.clampMaxFrameSize(http2Config.maxFrameSize)
 
@@ -132,6 +140,14 @@ extension ChannelPipeline.SynchronousOperations {
     NIOAsyncChannel<ClientConnectionEvent, Void>,
     NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
   ) {
+    if let flushCoalescing = config.connection.flushCoalescing {
+      let coalescing = FlushCoalescingHandler(
+        maxFlushDelay: TimeAmount(flushCoalescing.maxFlushDelay),
+        maxBytes: flushCoalescing.maxBytes
+      )
+      try self.addHandler(coalescing)
+    }
+
     let clampedTargetWindowSize = self.clampTargetWindowSize(config.http2.targetWindowSize)
     let clampedMaxFrameSize = self.clampMaxFrameSize(config.http2.maxFrameSize)
 

--- a/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCNIOTransportCore/Server/HTTP2ServerTransport.swift
@@ -123,23 +123,64 @@ extension HTTP2ServerTransport.Config {
     /// - SeeAlso: gRFC A8 for client side keepalive, and gRFC A9 for server connection management.
     public var keepalive: Keepalive
 
+    /// Configuration for flush coalescing.
+    ///
+    /// Flush coalescing delays flushing outbound writes on the HTTP/2 connection to batch them
+    /// together, reducing the number of syscalls. For high-traffic workloads this typically
+    /// reduces both CPU usage and latency as fewer, larger writes are more efficient. For
+    /// low-traffic workloads the delay may add a small amount of latency (bounded by
+    /// ``FlushCoalescing/maxFlushDelay``) as there are fewer writes to coalesce.
+    ///
+    /// If `nil`, flush coalescing is disabled and each flush is passed through immediately.
+    @available(gRPCSwiftNIOTransport 2.8, *)
+    public var flushCoalescing: FlushCoalescing?
+
+    /// Creates a connection configuration.
+    ///
+    /// New properties and features added to `Connection` are disabled by default when using
+    /// this initializer. Use ``defaults`` to get a configuration with all features enabled
+    /// at their default values.
     public init(
       maxAge: Duration?,
       maxGraceTime: Duration?,
       maxIdleTime: Duration?,
       keepalive: Keepalive
     ) {
+      self.init(
+        maxAge: maxAge,
+        maxGraceTime: maxGraceTime,
+        maxIdleTime: maxIdleTime,
+        keepalive: keepalive,
+        flushCoalescing: nil
+      )
+    }
+
+    @available(gRPCSwiftNIOTransport 2.8, *)
+    private init(
+      maxAge: Duration?,
+      maxGraceTime: Duration?,
+      maxIdleTime: Duration?,
+      keepalive: Keepalive,
+      flushCoalescing: FlushCoalescing?
+    ) {
       self.maxAge = maxAge
       self.maxGraceTime = maxGraceTime
       self.maxIdleTime = maxIdleTime
       self.keepalive = keepalive
+      self.flushCoalescing = flushCoalescing
     }
 
     /// Default values. The max connection age, max grace time, and max idle time default to
     /// `nil` (i.e. infinite). See ``HTTP2ServerTransport/Config/Keepalive/defaults`` for keepalive
-    /// defaults.
+    /// defaults. Flush coalescing is enabled with default values.
     public static var defaults: Self {
-      Self(maxAge: nil, maxGraceTime: nil, maxIdleTime: nil, keepalive: .defaults)
+      Self(
+        maxAge: nil,
+        maxGraceTime: nil,
+        maxIdleTime: nil,
+        keepalive: .defaults,
+        flushCoalescing: .defaults
+      )
     }
   }
 
@@ -220,6 +261,50 @@ extension HTTP2ServerTransport.Config {
     /// Default values; no callbacks are set.
     public static var defaults: Self {
       Self(onBindTCPListener: nil, onAcceptTCPConnection: nil, onAcceptHTTP2Stream: nil)
+    }
+  }
+}
+
+@available(gRPCSwiftNIOTransport 2.0, *)
+extension HTTP2ServerTransport.Config.Connection {
+  /// Flush coalescing batches together writes to reduce the overhead from syscalls.
+  ///
+  /// A channel handler intercepts flush events on the HTTP/2 connection channel and delays them
+  /// until one of the following conditions is met:
+  /// 1. ``maxFlushDelay`` has elapsed since a flush was first requested,
+  /// 2. At least ``maxBytes`` bytes have been written since the previous flush, or
+  /// 3. The channel becomes unwritable (i.e. the outbound buffer has hit the high-water mark).
+  ///
+  /// This means that under high load, writes naturally accumulate and are flushed together in
+  /// fewer, larger batches. This reduces per-write overhead and typically improves both throughput
+  /// and latency.
+  ///
+  /// Under low load there are fewer writes to coalesce so flushes are typically delayed by
+  /// up to ``maxFlushDelay``. If your workload is latency-sensitive and low-throughput then
+  /// disabling coalescing (by setting
+  /// ``HTTP2ServerTransport/Config/Connection/flushCoalescing`` to `nil`) may be preferable.
+  ///
+  /// The default values (see ``defaults``) aim to provide a good balance for most workloads
+  /// without adding significant latency.
+  @available(gRPCSwiftNIOTransport 2.8, *)
+  public struct FlushCoalescing: Sendable, Hashable {
+    /// The maximum delay between a flush being requested and it being performed.
+    public var maxFlushDelay: Duration
+
+    /// The number of bytes to buffer before a flush is emitted, regardless of the delay.
+    public var maxBytes: Int
+
+    /// Creates a new flush coalescing configuration.
+    ///
+    /// - SeeAlso: ``defaults``.
+    public init(maxFlushDelay: Duration, maxBytes: Int) {
+      self.maxFlushDelay = maxFlushDelay
+      self.maxBytes = maxBytes
+    }
+
+    /// Default values. The max flush delay is 100μs and the max bytes is 64KiB.
+    public static var defaults: Self {
+      Self(maxFlushDelay: .microseconds(100), maxBytes: 64 * 1024)
     }
   }
 }

--- a/Tests/GRPCNIOTransportCoreTests/Internal/FlushCoalescingHandlerTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Internal/FlushCoalescingHandlerTests.swift
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import GRPCNIOTransportCore
+
+/// Counts the number of flushes that pass through.
+private final class FlushCountingHandler: ChannelOutboundHandler {
+  typealias OutboundIn = ByteBuffer
+  typealias OutboundOut = ByteBuffer
+
+  var flushCount = 0
+
+  func flush(context: ChannelHandlerContext) {
+    self.flushCount += 1
+    context.flush()
+  }
+}
+
+struct FlushCoalescingHandlerTests {
+  private func makePipeline(
+    maxFlushDelay: TimeAmount,
+    maxBytes: Int
+  ) -> (channel: EmbeddedChannel, pre: FlushCountingHandler, post: FlushCountingHandler) {
+    let pre = FlushCountingHandler()
+    let coalescing = FlushCoalescingHandler(maxFlushDelay: maxFlushDelay, maxBytes: maxBytes)
+    let post = FlushCountingHandler()
+    let channel = EmbeddedChannel(handlers: [post, coalescing, pre])
+    return (channel, pre, post)
+  }
+
+  @Test("Write and flush below threshold schedules delayed flush")
+  func writeAndFlushBelowThreshold() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 1024)
+    defer { _ = try? channel.finish() }
+
+    #expect(pre.flushCount == 0)
+    #expect(post.flushCount == 0)
+    let buffer = channel.allocator.buffer(string: "hello")
+    channel.writeAndFlush(buffer, promise: nil)
+
+    // Below threshold, no flushes in post.
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 0)
+
+    // Data should still be written through (just not flushed).
+    #expect(try channel.readOutbound(as: ByteBuffer.self) == nil)
+
+    // Advance time  to trigger the flush.
+    channel.embeddedEventLoop.advanceTime(by: .milliseconds(10))
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+    let out = try channel.readOutbound(as: ByteBuffer.self)
+    #expect(out == buffer)
+  }
+
+  @Test("Flush triggered immediately when byte threshold reached")
+  func flushOnByteThreshold() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 32)
+    defer { _ = try? channel.finish() }
+
+    // Write enough bytes to exceed the threshold.
+    let buffer = channel.allocator.buffer(repeating: 0, count: 32)
+    channel.writeAndFlush(buffer, promise: nil)
+
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Multiple flushes coalesced into one")
+  func multipleFlushesCoalesced() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 1024)
+    defer { _ = try? channel.finish() }
+
+    // Write small amounts and flush multiple times.
+    for _ in 0 ..< 5 {
+      let buffer = channel.allocator.buffer(string: "hi")
+      channel.writeAndFlush(buffer, promise: nil)
+    }
+
+    // None should have propagated yet.
+    #expect(pre.flushCount == 5)
+    #expect(post.flushCount == 0)
+
+    // Advance time to trigger the delayed flush.
+    channel.embeddedEventLoop.advanceTime(by: .milliseconds(10))
+
+    // All flushes should have been coalesced into one.
+    #expect(pre.flushCount == 5)  // Still five
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Byte threshold reached across multiple writes triggers flush")
+  func byteThresholdAcrossMultipleWrites() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 32)
+    defer { _ = try? channel.finish() }
+
+    // First write + flush: below threshold.
+    let buffer = channel.allocator.buffer(repeating: 0, count: 16)
+    channel.writeAndFlush(buffer, promise: nil)
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 0)
+
+    // Second write hits byte limit.
+    channel.writeAndFlush(buffer, promise: nil)
+    #expect(pre.flushCount == 2)
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Channel close forces pending flush")
+  func channelCloseCancelsPendingFlush() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 1024)
+    defer { _ = try? channel.finish() }
+
+    let buffer = channel.allocator.buffer(string: "hi")
+    channel.writeAndFlush(buffer, promise: nil)
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 0)
+
+    // Close the channel, which forces a flush.
+    let close = channel.close()
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+
+    // Let the close happen.
+    channel.embeddedEventLoop.run()
+    try close.wait()
+
+    // Advance time: the callback should have been cancelled so no additional flush.
+    channel.embeddedEventLoop.advanceTime(by: .milliseconds(10))
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Writability change causes flush")
+  func channelUnwritableTriggersFlush() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 1024)
+    defer { _ = try? channel.finish() }
+
+    let buffer = channel.allocator.buffer(string: "hi")
+    channel.writeAndFlush(buffer, promise: nil)
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 0)
+
+    // Trigger a writability change notification which should trigger the flush.
+    channel.isWritable = false
+    channel.pipeline.fireChannelWritabilityChanged()
+
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Write without flush does not trigger flush")
+  func writeWithoutFlush() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 32)
+    defer { _ = try? channel.finish() }
+
+    // Write more than max bytes but don't flush.
+    let buffer = channel.allocator.buffer(repeating: 0, count: 64)
+    channel.write(buffer, promise: nil)
+
+    #expect(pre.flushCount == 0)
+    #expect(post.flushCount == 0)
+
+    // Still not flush after the deadline.
+    channel.embeddedEventLoop.advanceTime(by: .milliseconds(10))
+    #expect(pre.flushCount == 0)
+    #expect(post.flushCount == 0)
+
+    // Now flush.
+    channel.flush()
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+  }
+
+  @Test("Pending state reset after flush")
+  func pendingResetAfterFlush() throws {
+    let (channel, pre, post) = self.makePipeline(maxFlushDelay: .milliseconds(10), maxBytes: 32)
+    defer { _ = try? channel.finish() }
+
+    // First batch: write enough to trigger immediate flush.
+    let buffer = channel.allocator.buffer(repeating: 0, count: 32)
+    channel.writeAndFlush(buffer, promise: nil)
+    #expect(pre.flushCount == 1)
+    #expect(post.flushCount == 1)
+
+    // Second batch: write a small amount. Should not flush immediately.
+    let smol = channel.allocator.buffer(string: "smol")
+    channel.writeAndFlush(smol, promise: nil)
+    #expect(pre.flushCount == 2)
+    #expect(post.flushCount == 1)
+
+    // Advance time to get the delayed flush.
+    channel.embeddedEventLoop.advanceTime(by: .milliseconds(10))
+    #expect(pre.flushCount == 2)
+    #expect(post.flushCount == 2)
+  }
+}


### PR DESCRIPTION
Motivation:

As RPCs are backed by NIOAsyncChannel a lot of the natural structure for coalescing flush events is lost: each write from the NIOAsyncChannel results in a flush and as that has to execute onto the event loop it typically results in one flush per-write. Flushes can be coalesced if multiple happen on the same loop tick but that's very rare.

Modifications:

- Add a coalescing handler which coalesces flushes in the http/2 connection channel by delaying a flush by a maximum deadline or until enough bytes are written. This can dramatically decrease the number of syscalls.
- Plumb this through to be configurable

Result:

- Fewer flushes, better perf for many workloads