### PR TITLE
Resume stream continuation if LB is ready

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/GRPCChannel.swift
@@ -388,25 +388,30 @@ extension GRPCChannel {
     let id = QueueEntryID()
     return try await withTaskCancellationHandler {
       try await withCheckedThrowingContinuation { continuation in
-        // Explicitly adding the types works around: https://github.com/swiftlang/swift/issues/78112
-        let (enqueued, loadBalancer) = self.state.withLock { state -> (Bool, LoadBalancer?) in
+        let onEnqueue = self.state.withLock { state in
           state.enqueue(continuation: continuation, waitForReady: waitForReady, id: id)
         }
 
-        if let loadBalancer = loadBalancer {
+        switch onEnqueue {
+        case .poke(let loadBalancer):
           // Attempting to pick a subchannel will trigger a connect event if the subchannel is idle.
           _ = loadBalancer.pickSubchannel()
-        }
 
-        // Not enqueued because the channel is shutdown or shutting down.
-        if !enqueued {
+        case .use(let loadBalancer):
+          // Became ready after being told to join the queue.
+          continuation.resume(with: .success(loadBalancer))
+
+        case .enqueued:
+          if Task.isCancelled {
+            let dequeued = self.state.withLock { state in
+              state.dequeueContinuation(id: id)
+            }
+            dequeued?.resume(throwing: CancellationError())
+          }
+
+        case .rejected:
           let error = RPCError(code: .unavailable, message: "channel is shutdown")
           continuation.resume(throwing: error)
-        } else if Task.isCancelled {
-          let dequeued = self.state.withLock { state in
-            state.dequeueContinuation(id: id)
-          }
-          dequeued?.resume(throwing: CancellationError())
         }
       }
     } onCancel: {
@@ -1043,25 +1048,43 @@ extension GRPCChannel.StateMachine {
     return onMakeStream
   }
 
+  enum OnEnqueue {
+    // Ask the LB to pick a subchannel to trigger a connect.
+    case poke(LoadBalancer)
+    // Use the LB immediately, it's ready.
+    case use(LoadBalancer)
+    // The continuation was enqueued, wait.
+    case enqueued
+    // The request to enqueue was rejected because the channel is shutting down or
+    // shutdown, fail the continuation.
+    case rejected
+  }
+
   mutating func enqueue(
     continuation: CheckedContinuation<LoadBalancer, any Error>,
     waitForReady: Bool,
     id: QueueEntryID
-  ) -> (enqueued: Bool, loadBalancer: LoadBalancer?) {
+  ) -> OnEnqueue {
     switch self.state {
     case .notRunning(var state):
       self.state = ._modifying
       state.queue.append(continuation: continuation, waitForReady: waitForReady, id: id)
       self.state = .notRunning(state)
-      return (true, nil)
+      return .enqueued
     case .running(var state):
       self.state = ._modifying
-      state.queue.append(continuation: continuation, waitForReady: waitForReady, id: id)
-      self.state = .running(state)
-      // If idle then return the current load balancer so that it can be told to start connecting.
-      return (true, state.connectivityState == .idle ? state.current : nil)
+      if state.connectivityState == .ready {
+        // Became ready between being told to join the queue and creating a continuation.
+        self.state = .running(state)
+        return .use(state.current)
+      } else {
+        state.queue.append(continuation: continuation, waitForReady: waitForReady, id: id)
+        self.state = .running(state)
+        // If idle then return the current load balancer so that it can be told to start connecting.
+        return state.connectivityState == .idle ? .poke(state.current) : .enqueued
+      }
     case .stopping, .stopped:
-      return (false, nil)
+      return .rejected
     case ._modifying:
       fatalError("Invalid state")
     }

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelEnqueueRaceTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/GRPCChannelEnqueueRaceTests.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import Testing
+
+@testable import GRPCNIOTransportCore
+
+struct GRPCChannelEnqueueRaceTests {
+  /// Regression test: a stream request joins the queue while the load‑balancer
+  /// is `.connecting` (or `idle`). The load balancer transitions to `.ready`
+  /// (draining the empty queue) *before* `enqueue` acquires the lock on the
+  /// state‑machine.
+  @Test
+  @available(gRPCSwiftNIOTransport 2.8, *)
+  func enqueueAfterLoadBalancerBecomesReadyDoesNotStrand() async throws {
+    var sm = GRPCChannel.StateMachine()
+    sm.start()
+
+    // Install a pick-first load-balancer.
+    let pickFirst = PickFirstLoadBalancer(
+      connector: NeverConnector(),
+      authority: nil,
+      backoff: .defaults,
+      defaultCompression: .none,
+      enabledCompression: .none
+    )
+
+    let onChange = sm.changeLoadBalancerKind(to: .pickFirst(.init())) {
+      .pickFirst(pickFirst)
+    }
+
+    guard case .runLoadBalancer(let lb, stop: let toStop) = onChange else {
+      Issue.record("Expected .runLoadBalancer, got \(onChange)")
+      return
+    }
+
+    #expect(toStop == nil)
+    #expect(lb.id == pickFirst.id)
+
+    // Walk the load-balancer through .idle -> .connecting -> .ready. The queue is
+    // empty so neither transition resumes any continuations.
+    var actions = sm.loadBalancerStateChanged(to: .connecting, id: lb.id)
+    #expect(actions.resumeContinuations == nil)
+    #expect(actions.publishState == .connecting)
+
+    actions = sm.loadBalancerStateChanged(to: .ready, id: lb.id)
+    #expect(actions.publishState == .ready)
+
+    if let resumable = actions.resumeContinuations {
+      #expect(resumable.continuations.isEmpty)
+      #expect(try resumable.result.map { $0.id }.get() == lb.id)
+    } else {
+      Issue.record("Expected resumeContinuations to have the LB")
+    }
+
+    // Call `enqueue`: this is where the race could happen. Previously the state machine
+    // would store the continuation when the connectivity state is .ready.
+    let resolved: LoadBalancer = try await withCheckedThrowingContinuation { cont in
+      let outcome = sm.enqueue(continuation: cont, waitForReady: false, id: QueueEntryID())
+      switch outcome {
+      case .use(let lb):
+        cont.resume(returning: lb)
+      case .poke, .enqueued, .rejected:
+        cont.resume(throwing: UnexpectedOutcome(description: "\(outcome)"))
+      }
+    }
+    #expect(resolved.id == pickFirst.id)
+  }
+
+  private struct UnexpectedOutcome: Error, CustomStringConvertible {
+    let description: String
+  }
+}


### PR DESCRIPTION
Motivation:

When requesting a stream from GRPCChannel, if it isn't yet ready a continuation will be enqueued. When it becomes ready the continuation will be dequeued and resumed. However, there's a small timing window between the state machine telling the caller to join the queue and the caller creating the continuation and enqueing it. During this window the channel could become ready and the continuation would never be resumed.o

Modifications:

- Resume the continuation if the channel is in the ready state during the call to enqueue

Result:

Fewer hangs