### PR TITLE
Honour certificate verification mode when custom trust roots are set (TransportServices)

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/Config+TLS.swift
@@ -324,8 +324,22 @@ extension HTTP2ClientTransport.TransportServices {
 
 @available(gRPCSwiftNIOTransport 2.0, *)
 extension NWProtocolTLS.Options {
-  func setUpVerifyBlock(trustRootsSource: TLSConfig.TrustRootsSource) {
-    if let (verifyQueue, verifyBlock) = trustRootsSource.makeTrustRootsConfig() {
+  func setUpVerifyBlock(
+    trustRootsSource: TLSConfig.TrustRootsSource,
+    verification: TLSConfig.CertificateVerification,
+    evaluatingServerCertificates: Bool
+  ) {
+    // With verification disabled there is nothing to evaluate; installing
+    // the block would evaluate the peer's chain anyway and could fail the
+    // handshake despite verification being explicitly turned off.
+    if verification == .noVerification {
+      return
+    }
+
+    if let (verifyQueue, verifyBlock) = trustRootsSource.makeTrustRootsConfig(
+      verification: verification,
+      evaluatingServerCertificates: evaluatingServerCertificates
+    ) {
       sec_protocol_options_set_verify_block(
         self.securityProtocolOptions,
         verifyBlock,
@@ -337,7 +351,10 @@ extension NWProtocolTLS.Options {
 
 @available(gRPCSwiftNIOTransport 2.0, *)
 extension TLSConfig.TrustRootsSource {
-  internal func makeTrustRootsConfig() -> (DispatchQueue, sec_protocol_verify_t)? {
+  internal func makeTrustRootsConfig(
+    verification: TLSConfig.CertificateVerification,
+    evaluatingServerCertificates: Bool
+  ) -> (DispatchQueue, sec_protocol_verify_t)? {
     switch self.wrapped {
     case .certificates(let certificates):
       let verifyQueue = DispatchQueue(label: "io.grpc.CertificateVerification")
@@ -371,6 +388,16 @@ extension TLSConfig.TrustRootsSource {
         } catch {
           verifyCompleteCallback(false)
           return
+        }
+
+        // The trust arrives configured with the platform's default SSL
+        // policy, which includes matching the peer's certificate against the
+        // endpoint's hostname. `.noHostnameVerification` promises chain
+        // validation without the hostname check, so re-policy the trust for
+        // SSL use with no hostname before evaluating.
+        if verification == .noHostnameVerification {
+          let policy = SecPolicyCreateSSL(evaluatingServerCertificates, nil)
+          SecTrustSetPolicies(actualTrust, policy)
         }
 
         SecTrustSetAnchorCertificates(actualTrust, customAnchors as CFArray)

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -439,7 +439,11 @@ extension NWProtocolTLS.Options {
       )
     }
 
-    self.setUpVerifyBlock(trustRootsSource: tlsConfig.trustRoots)
+    self.setUpVerifyBlock(
+      trustRootsSource: tlsConfig.trustRoots,
+      verification: tlsConfig.serverCertificateVerification,
+      evaluatingServerCertificates: true
+    )
   }
 }
 #endif

--- a/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCNIOTransportHTTP2TransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -334,7 +334,11 @@ extension NWProtocolTLS.Options {
       )
     }
 
-    self.setUpVerifyBlock(trustRootsSource: tlsConfig.trustRoots)
+    self.setUpVerifyBlock(
+      trustRootsSource: tlsConfig.trustRoots,
+      verification: tlsConfig.clientCertificateVerification,
+      evaluatingServerCertificates: false
+    )
   }
 }
 #endif

--- a/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
+++ b/Tests/GRPCNIOTransportHTTP2Tests/HTTP2TransportTLSEnabledTests.swift
@@ -501,6 +501,41 @@ struct HTTP2TransportTLSEnabledTests {
   }
 
   @Test(
+    "Client using noHostnameVerification connects despite a non-matching hostname",
+    arguments: TransportKind.clientsWithTLS,
+    TransportKind.serversWithTLS
+  )
+  @available(gRPCSwiftNIOTransport 2.0, *)
+  // Like testClientFailsServerValidation, but with hostname verification
+  // disabled the mismatched hostname must be ignored: the certificate chain
+  // still validates against the custom trust roots, so the RPC succeeds.
+  func testClientNoHostnameVerificationIgnoresHostname(
+    clientTransport: TransportKind,
+    serverTransport: TransportKind
+  ) async throws {
+    let certificateKeyPairs = try SelfSignedCertificateKeyPairs()
+    let clientTransportConfig = self.makeDefaultTLSClientConfig(
+      for: clientTransport,
+      certificateKeyPairs: certificateKeyPairs,
+      authority: "wrong-hostname",
+      serverCertificateVerification: .noHostnameVerification
+    )
+    let serverTransportConfig = self.makeDefaultTLSServerConfig(
+      for: serverTransport,
+      certificateKeyPairs: certificateKeyPairs
+    )
+
+    try await self.withClientAndServer(
+      clientConfig: clientTransportConfig,
+      serverConfig: serverTransportConfig
+    ) { control in
+      await #expect(throws: Never.self) {
+        try await self.executeUnaryRPC(control: control)
+      }
+    }
+  }
+
+  @Test(
     "Error is surfaced when server fails client verification",
     arguments: TransportKind.clientsWithTLS,
     TransportKind.clientsWithTLS
@@ -746,7 +781,8 @@ struct HTTP2TransportTLSEnabledTests {
   private func makeDefaultTLSClientConfig(
     for transportSecurity: TransportKind,
     certificateKeyPairs: SelfSignedCertificateKeyPairs,
-    authority: String? = "localhost"
+    authority: String? = "localhost",
+    serverCertificateVerification: TLSConfig.CertificateVerification = .fullVerification
   ) -> ClientConfig {
     switch transportSecurity {
     case .posix:
@@ -755,6 +791,7 @@ struct HTTP2TransportTLSEnabledTests {
         $0.trustRoots = .certificates([
           .bytes(certificateKeyPairs.server.certificate, format: .der)
         ])
+        $0.serverCertificateVerification = serverCertificateVerification
       }
       config.transport.http2.authority = authority
       return .posix(config)
@@ -766,6 +803,7 @@ struct HTTP2TransportTLSEnabledTests {
         $0.trustRoots = .certificates([
           .bytes(certificateKeyPairs.server.certificate, format: .der)
         ])
+        $0.serverCertificateVerification = serverCertificateVerification
       }
       config.transport.http2.authority = authority
       return .transportServices(config)


### PR DESCRIPTION
Fixes #184.

## Motivation

With `trustRoots: .certificates(...)`, the TransportServices transports install a verify block that anchors the custom roots and then calls `SecTrustEvaluateAsyncWithError` on the trust exactly as Network.framework configured it — with the default SSL policy, which includes hostname matching. The configured `CertificateVerification` mode is never consulted there:

- `.noHostnameVerification` behaves like full verification: any certificate whose SANs don't cover the dialled endpoint is rejected (`errSSLBadCert`), even though the chain validates against the custom roots. This breaks private-CA deployments whose certs deliberately carry no DNS/IP SANs, and peers dialled by IP address. The identical configuration works with the Posix transport, where the mode maps to NIOSSL's `certificateVerification = .noHostnameVerification`.
- `.noVerification` still installs the evaluating block and can fail the handshake despite verification being explicitly disabled.

## Modifications

The verify block now receives the verification mode and whether it is evaluating server or client certificates:

- `.noHostnameVerification`: the trust is re-policied with `SecPolicyCreateSSL(<role>, nil)` before evaluation — chain validation against the custom anchors is unchanged, hostname matching is skipped.
- `.noVerification`: no verify block is installed (the callers already set `sec_protocol_options_set_peer_authentication_required(false)` for this mode), matching NIOSSL semantics.
- `.fullVerification`: behaviour unchanged.

## Result

`.noHostnameVerification` + custom trust roots connects when the chain is valid but the hostname doesn't match, on both client and server TransportServices transports, matching the Posix transport.

New regression test (`testClientNoHostnameVerificationIgnoresHostname`) covers all client/server transport combinations; without the source change the two TransportServices-client cases fail with `NWError.tls(-9808)`. Existing TLS suites pass (`HTTP2TransportTLSEnabledTests`, `TLSConfigurationTests`).