### PR TITLE
Don't use IP literals for TLS SNI

### DIFF
--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -115,18 +115,39 @@ package final class Connection: Sendable {
     self.event.stream
   }
 
-  private static func sanitizeAuthorityForSNI(_ authority: String) -> String {
+  private static func sanitizeAuthorityForSNI(_ authority: String) -> String? {
+    // A bare IP literal is never a valid SNI hostname (RFC 6066 § 3 permits
+    // only DNS hostnames, and NIOSSL enforces this by failing the connection
+    // before the handshake starts). Check before stripping a port: the
+    // stripping below would otherwise mangle bare IPv6 literals like "::1".
+    if Self.isIPLiteral(authority) {
+      return nil
+    }
+
     // Strip off a trailing ":{PORT}". Look for the last non-digit byte, if it's
     // a colon then keep everything up to that index.
     let index = authority.utf8.lastIndex { byte in
       return byte < UInt8(ascii: "0") || byte > UInt8(ascii: "9")
     }
 
+    var host: String
     if let index = index, authority.utf8[index] == UInt8(ascii: ":") {
-      return String(authority.utf8[..<index])!
+      host = String(authority.utf8[..<index])!
     } else {
-      return authority
+      host = authority
     }
+
+    // Undo the bracketing applied to IPv6 addresses in authorities
+    // (e.g. "[2001:db8::1]:443").
+    if host.utf8.first == UInt8(ascii: "["), host.utf8.last == UInt8(ascii: "]") {
+      host = String(host.dropFirst().dropLast())
+    }
+
+    return Self.isIPLiteral(host) ? nil : host
+  }
+
+  private static func isIPLiteral(_ host: String) -> Bool {
+    (try? NIOCore.SocketAddress(ipAddress: host, port: 0)) != nil
   }
 
   package init(
@@ -138,7 +159,7 @@ package final class Connection: Sendable {
   ) {
     self.address = address
     self.authority = authority
-    self.sniServerHostname = authority.map { Self.sanitizeAuthorityForSNI($0) }
+    self.sniServerHostname = authority.flatMap { Self.sanitizeAuthorityForSNI($0) }
     self.defaultCompression = defaultCompression
     self.enabledCompression = enabledCompression
     self.http2Connector = http2Connector

--- a/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
+++ b/Sources/GRPCNIOTransportCore/Client/Connection/Connection.swift
@@ -130,17 +130,17 @@ package final class Connection: Sendable {
       return byte < UInt8(ascii: "0") || byte > UInt8(ascii: "9")
     }
 
-    var host: String
+    let host: String
     if let index = index, authority.utf8[index] == UInt8(ascii: ":") {
       host = String(authority.utf8[..<index])!
     } else {
       host = authority
     }
 
-    // Undo the bracketing applied to IPv6 addresses in authorities
-    // (e.g. "[2001:db8::1]:443").
+    // Square brackets imply an IPv6 literal (e.g. "[2001:db8::1]:443"),
+    // which can't be used for SNI.
     if host.utf8.first == UInt8(ascii: "["), host.utf8.last == UInt8(ascii: "]") {
-      host = String(host.dropFirst().dropLast())
+      return nil
     }
 
     return Self.isIPLiteral(host) ? nil : host

--- a/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCNIOTransportCoreTests/Client/Connection/ConnectionTests.swift
@@ -202,7 +202,7 @@ final class ConnectionTests: XCTestCase {
     }
   }
 
-  private func testAuthorityIsSanitized(authority: String, expected: String) async throws {
+  private func testAuthorityIsSanitized(authority: String, expected: String?) async throws {
     let recorder = SNIRecordingConnector()
     let connection = Connection(
       address: .ipv4(host: "ignored", port: 0),
@@ -237,6 +237,30 @@ final class ConnectionTests: XCTestCase {
     try await self.testAuthorityIsSanitized(
       authority: "foo.example.com:abc123",
       expected: "foo.example.com:abc123"
+    )
+  }
+
+  func testAuthorityWithIPLiteralHasNoSNI() async throws {
+    // IP literals aren't valid SNI hostnames (RFC 6066 § 3) and NIOSSL
+    // refuses them, failing the connection before the handshake starts.
+    try await self.testAuthorityIsSanitized(
+      authority: "127.0.0.1",
+      expected: nil
+    )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "127.0.0.1:9443",
+      expected: nil
+    )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "::1",
+      expected: nil
+    )
+
+    try await self.testAuthorityIsSanitized(
+      authority: "[2001:db8::1]:443",
+      expected: nil
     )
   }
 }


### PR DESCRIPTION
## Motivation

When a connection's authority contains an IP literal — e.g. a `.dns` target created with an IP address, which is common when callers resolve addresses themselves (multi-homed servers, NAT64 synthesis on mobile clients, health checks by address) — the literal is passed to the TLS handshake as the SNI server hostname. RFC 6066 § 3 only permits DNS hostnames in SNI, and NIOSSL enforces this: the connection fails with `NIOSSLExtraError.cannotUseIPAddressInSNI` before the handshake starts, surfacing to callers as `unavailable: Could not establish a connection…`.

`SocketAddress.sniHostname` already applies exactly this rule ("Literal IP addresses aren't allowed in the SNI hostname") — but the authority-derived hostname takes precedence over it and doesn't.

## Modifications

`Connection.sanitizeAuthorityForSNI` now returns `nil` for IP literals — bare IPv4/IPv6, with a trailing port, or bracketed IPv6 — after its existing port-stripping. The literal check runs before port-stripping too, since that logic would otherwise mangle bare IPv6 literals like `::1`. `sniServerHostname` then falls back through the existing `?? self.address.sniHostname` path, so such connections are made without SNI instead of failing.

## Result

Dialling an IP literal over TLS connects (subject to the configured certificate verification) instead of failing with `cannotUseIPAddressInSNI`. Hostname authorities are unaffected.

Extended the existing `testAuthorityIsSanitized` harness with IP-literal cases (`127.0.0.1`, `127.0.0.1:9443`, `::1`, `[2001:db8::1]:443`), all expecting no SNI.