### PR TITLE
Update links and references to point to grpc-swift-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ DerivedData/
 .swiftpm
 build
 /protoc-gen-swift
-/protoc-gen-grpc-swift
+/protoc-gen-grpc-swift-2
 third_party/**
 /Echo
 /EchoNIO

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ DerivedData/
 .swiftpm
 build
 /protoc-gen-swift
-/protoc-gen-grpc-swift-2
+/protoc-gen-grpc-swift
 third_party/**
 /Echo
 /EchoNIO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
 Please refer to the contributing guide in the
-[`grpc/grpc-swift`](https://github.com/grpc/grpc-swift) repository.
+[`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2) repository.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # gRPC Swift NIO Transport
 
 This repository contains high-performance HTTP/2 client and server transport
-implementations for [gRPC Swift][gh-grpc-swift] built on top of
+implementations for [gRPC Swift][gh-grpc-swift-2] built on top of
 [SwiftNIO][gh-swift-nio].
 
 - 📚 **Documentation** is available on the [Swift Package Index][spi-grpc-swift-nio-transport]
-- 🎓 **Tutorials** are available in the documentation for `grpc/grpc-swift` on
-  the [Swift Package Index][spi-grpc-swift].
+- 🎓 **Tutorials** are available in the documentation for `grpc/grpc-swift-2` on
+  the [Swift Package Index][spi-grpc-swift-2].
 - 💻 **Examples** are available in the `Examples` directory of the
-  [`grpc/grpc-swift`](https://github.com/grpc/grpc-swift-2) repository
+  [`grpc/grpc-swift-2`][gh-grpc-swift-2] repository
 - 🚀 **Contributions** are welcome, please see [CONTRIBUTING.md](CONTRIBUTING.md)
 - 🪪 **License** is Apache 2.0, repeated in [LICENSE](License)
 - 🔒 **Security** issues should be reported via the process in [SECURITY.md](SECURITY.md)
 
 [gh-swift-nio]: https://github.com/apple/swift-nio
-[gh-grpc-swift]: https://github.com/grpc/grpc-swift-2
+[gh-grpc-swift-2]: https://github.com/grpc/grpc-swift-2
 [spi-grpc-swift-nio-transport]: https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation
+[spi-grpc-swift-2]: https://swiftpackageindex.com/grpc/grpc-swift-2/documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Security
 
 Please refer to [SECURITY.md] in the
-[`grpc/grpc-swift`](https://github.com/grpc/grpc-swift) repository.
+[`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2) repository.


### PR DESCRIPTION
There were a few outdated links from when `grpc/grpc-swift` was the repo in use.
Hopefully the search was thorough, used the following regexp: `"grpc-swift(?!-)"`.