### PR TITLE
Regenerate integration test sources from proto

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -20,3 +20,19 @@ jobs:
       - name: Run license check
         run: |
           ./dev/license-check.sh
+
+  check-generated-code:
+    name: Check generated code
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Run soundness checks
+        run: |
+          ./dev/check-generated-code.sh

--- a/.licenseignore
+++ b/.licenseignore
@@ -35,7 +35,7 @@ Snippets/*
 dev/git.commit.template
 dev/version-bump.commit.template
 .unacceptablelanguageignore
-IntegrationTests/grpc-performance-tests/Sources/Generated/*
+IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/*
 LICENSE
 **/*.swift
 Sources/CGRPCNIOTransportZlib/*

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_core_stats.pb.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_core_stats.pb.swift
@@ -29,12 +29,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-package struct Grpc_Core_Bucket: Sendable {
+package nonisolated struct Grpc_Core_Bucket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ package struct Grpc_Core_Bucket: Sendable {
   package init() {}
 }
 
-package struct Grpc_Core_Histogram: Sendable {
+package nonisolated struct Grpc_Core_Histogram: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -60,7 +60,7 @@ package struct Grpc_Core_Histogram: Sendable {
   package init() {}
 }
 
-package struct Grpc_Core_Metric: Sendable {
+package nonisolated struct Grpc_Core_Metric: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,7 +87,7 @@ package struct Grpc_Core_Metric: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Value: Equatable, Sendable {
+  package nonisolated enum OneOf_Value: Equatable, Sendable {
     case count(UInt64)
     case histogram(Grpc_Core_Histogram)
 
@@ -96,7 +96,7 @@ package struct Grpc_Core_Metric: Sendable {
   package init() {}
 }
 
-package struct Grpc_Core_Stats: Sendable {
+package nonisolated struct Grpc_Core_Stats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -110,9 +110,9 @@ package struct Grpc_Core_Stats: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.core"
+fileprivate nonisolated let _protobuf_package = "grpc.core"
 
-extension Grpc_Core_Bucket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Core_Bucket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Bucket"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}start\0\u{1}count\0")
 
@@ -147,7 +147,7 @@ extension Grpc_Core_Bucket: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
-extension Grpc_Core_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Core_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Histogram"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}buckets\0")
 
@@ -177,7 +177,7 @@ extension Grpc_Core_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Grpc_Core_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Core_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Metric"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{2}\u{9}count\0\u{1}histogram\0")
 
@@ -244,7 +244,7 @@ extension Grpc_Core_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 }
 
-extension Grpc_Core_Stats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Core_Stats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Stats"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metrics\0")
 

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -23,7 +23,7 @@
 // Source: grpc/testing/benchmark_service.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 import GRPCCore
 import GRPCProtobuf

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_control.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_control.grpc.swift
@@ -20,6 +20,6 @@
 // Source: grpc/testing/control.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 // This file contained no services.

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_control.pb.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_control.pb.swift
@@ -29,12 +29,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-package enum Grpc_Testing_ClientType: SwiftProtobuf.Enum, Swift.CaseIterable {
+package nonisolated enum Grpc_Testing_ClientType: SwiftProtobuf.Enum, Swift.CaseIterable {
   package typealias RawValue = Int
 
   /// Many languages support a basic distinction between using
@@ -81,7 +81,7 @@ package enum Grpc_Testing_ClientType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-package enum Grpc_Testing_ServerType: SwiftProtobuf.Enum, Swift.CaseIterable {
+package nonisolated enum Grpc_Testing_ServerType: SwiftProtobuf.Enum, Swift.CaseIterable {
   package typealias RawValue = Int
   case syncServer // = 0
   case asyncServer // = 1
@@ -129,7 +129,7 @@ package enum Grpc_Testing_ServerType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 }
 
-package enum Grpc_Testing_RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
+package nonisolated enum Grpc_Testing_RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
   package typealias RawValue = Int
   case unary // = 0
   case streaming // = 1
@@ -177,7 +177,7 @@ package enum Grpc_Testing_RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 /// Parameters of poisson process distribution, which is a good representation
 /// of activity coming in from independent identical stationary sources.
-package struct Grpc_Testing_PoissonParams: Sendable {
+package nonisolated struct Grpc_Testing_PoissonParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -192,7 +192,7 @@ package struct Grpc_Testing_PoissonParams: Sendable {
 
 /// Once an RPC finishes, immediately start a new one.
 /// No configuration parameters needed.
-package struct Grpc_Testing_ClosedLoopParams: Sendable {
+package nonisolated struct Grpc_Testing_ClosedLoopParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -202,7 +202,7 @@ package struct Grpc_Testing_ClosedLoopParams: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_LoadParams: Sendable {
+package nonisolated struct Grpc_Testing_LoadParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -227,7 +227,7 @@ package struct Grpc_Testing_LoadParams: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Load: Equatable, Sendable {
+  package nonisolated enum OneOf_Load: Equatable, Sendable {
     case closedLoop(Grpc_Testing_ClosedLoopParams)
     case poisson(Grpc_Testing_PoissonParams)
 
@@ -237,7 +237,7 @@ package struct Grpc_Testing_LoadParams: Sendable {
 }
 
 /// presence of SecurityParams implies use of TLS
-package struct Grpc_Testing_SecurityParams: Sendable {
+package nonisolated struct Grpc_Testing_SecurityParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -253,7 +253,7 @@ package struct Grpc_Testing_SecurityParams: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ChannelArg: Sendable {
+package nonisolated struct Grpc_Testing_ChannelArg: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -280,7 +280,7 @@ package struct Grpc_Testing_ChannelArg: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Value: Equatable, Sendable {
+  package nonisolated enum OneOf_Value: Equatable, Sendable {
     case strValue(String)
     case intValue(Int32)
 
@@ -289,7 +289,7 @@ package struct Grpc_Testing_ChannelArg: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ClientConfig: @unchecked Sendable {
+package nonisolated struct Grpc_Testing_ClientConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -427,7 +427,7 @@ package struct Grpc_Testing_ClientConfig: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-package struct Grpc_Testing_ClientStatus: Sendable {
+package nonisolated struct Grpc_Testing_ClientStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -449,7 +449,7 @@ package struct Grpc_Testing_ClientStatus: Sendable {
 }
 
 /// Request current stats
-package struct Grpc_Testing_Mark: Sendable {
+package nonisolated struct Grpc_Testing_Mark: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -462,7 +462,7 @@ package struct Grpc_Testing_Mark: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ClientArgs: Sendable {
+package nonisolated struct Grpc_Testing_ClientArgs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -487,7 +487,7 @@ package struct Grpc_Testing_ClientArgs: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Argtype: Equatable, Sendable {
+  package nonisolated enum OneOf_Argtype: Equatable, Sendable {
     case setup(Grpc_Testing_ClientConfig)
     case mark(Grpc_Testing_Mark)
 
@@ -496,7 +496,7 @@ package struct Grpc_Testing_ClientArgs: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ServerConfig: Sendable {
+package nonisolated struct Grpc_Testing_ServerConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -559,7 +559,7 @@ package struct Grpc_Testing_ServerConfig: Sendable {
   fileprivate var _payloadConfig: Grpc_Testing_PayloadConfig? = nil
 }
 
-package struct Grpc_Testing_ServerArgs: Sendable {
+package nonisolated struct Grpc_Testing_ServerArgs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -584,7 +584,7 @@ package struct Grpc_Testing_ServerArgs: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Argtype: Equatable, Sendable {
+  package nonisolated enum OneOf_Argtype: Equatable, Sendable {
     case setup(Grpc_Testing_ServerConfig)
     case mark(Grpc_Testing_Mark)
 
@@ -593,7 +593,7 @@ package struct Grpc_Testing_ServerArgs: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ServerStatus: Sendable {
+package nonisolated struct Grpc_Testing_ServerStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -620,7 +620,7 @@ package struct Grpc_Testing_ServerStatus: Sendable {
   fileprivate var _stats: Grpc_Testing_ServerStats? = nil
 }
 
-package struct Grpc_Testing_CoreRequest: Sendable {
+package nonisolated struct Grpc_Testing_CoreRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -630,7 +630,7 @@ package struct Grpc_Testing_CoreRequest: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_CoreResponse: Sendable {
+package nonisolated struct Grpc_Testing_CoreResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -643,7 +643,7 @@ package struct Grpc_Testing_CoreResponse: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_Void: Sendable {
+package nonisolated struct Grpc_Testing_Void: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -654,7 +654,7 @@ package struct Grpc_Testing_Void: Sendable {
 }
 
 /// A single performance scenario: input to qps_json_driver
-package struct Grpc_Testing_Scenario: @unchecked Sendable {
+package nonisolated struct Grpc_Testing_Scenario: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -723,7 +723,7 @@ package struct Grpc_Testing_Scenario: @unchecked Sendable {
 }
 
 /// A set of scenarios to be run with qps_json_driver
-package struct Grpc_Testing_Scenarios: Sendable {
+package nonisolated struct Grpc_Testing_Scenarios: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -737,7 +737,7 @@ package struct Grpc_Testing_Scenarios: Sendable {
 
 /// Basic summary that can be computed from ClientStats and ServerStats
 /// once the scenario has finished.
-package struct Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {
+package nonisolated struct Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -875,7 +875,7 @@ package struct Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {
 }
 
 /// Results of a single benchmark scenario.
-package struct Grpc_Testing_ScenarioResult: Sendable {
+package nonisolated struct Grpc_Testing_ScenarioResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -938,21 +938,21 @@ package struct Grpc_Testing_ScenarioResult: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.testing"
+fileprivate nonisolated let _protobuf_package = "grpc.testing"
 
-extension Grpc_Testing_ClientType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SYNC_CLIENT\0\u{1}ASYNC_CLIENT\0\u{1}OTHER_CLIENT\0\u{1}CALLBACK_CLIENT\0")
 }
 
-extension Grpc_Testing_ServerType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ServerType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SYNC_SERVER\0\u{1}ASYNC_SERVER\0\u{1}ASYNC_GENERIC_SERVER\0\u{1}OTHER_SERVER\0\u{1}CALLBACK_SERVER\0")
 }
 
-extension Grpc_Testing_RpcType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_RpcType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNARY\0\u{1}STREAMING\0\u{1}STREAMING_FROM_CLIENT\0\u{1}STREAMING_FROM_SERVER\0\u{1}STREAMING_BOTH_WAYS\0")
 }
 
-extension Grpc_Testing_PoissonParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_PoissonParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".PoissonParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}offered_load\0")
 
@@ -982,7 +982,7 @@ extension Grpc_Testing_PoissonParams: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Grpc_Testing_ClosedLoopParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClosedLoopParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClosedLoopParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1001,7 +1001,7 @@ extension Grpc_Testing_ClosedLoopParams: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Grpc_Testing_LoadParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LoadParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}closed_loop\0\u{1}poisson\0")
 
@@ -1068,7 +1068,7 @@ extension Grpc_Testing_LoadParams: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_SecurityParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_SecurityParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SecurityParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}use_test_ca\0\u{3}server_host_override\0\u{3}cred_type\0")
 
@@ -1108,7 +1108,7 @@ extension Grpc_Testing_SecurityParams: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Grpc_Testing_ChannelArg: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ChannelArg: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ChannelArg"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}str_value\0\u{3}int_value\0")
 
@@ -1170,7 +1170,7 @@ extension Grpc_Testing_ChannelArg: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_ClientConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientConfig"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}server_targets\0\u{3}client_type\0\u{3}security_params\0\u{3}outstanding_rpcs_per_channel\0\u{3}client_channels\0\u{4}\u{2}async_client_threads\0\u{3}rpc_type\0\u{4}\u{2}load_params\0\u{3}payload_config\0\u{3}histogram_params\0\u{3}core_list\0\u{3}core_limit\0\u{3}other_client_api\0\u{3}channel_args\0\u{3}threads_per_cq\0\u{3}messages_per_stream\0\u{3}use_coalesce_api\0\u{3}median_latency_collection_interval_millis\0\u{3}client_processes\0")
 
@@ -1366,7 +1366,7 @@ extension Grpc_Testing_ClientConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Grpc_Testing_ClientStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientStatus"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}stats\0")
 
@@ -1400,7 +1400,7 @@ extension Grpc_Testing_ClientStatus: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Grpc_Testing_Mark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_Mark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Mark"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}reset\0")
 
@@ -1430,7 +1430,7 @@ extension Grpc_Testing_Mark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Grpc_Testing_ClientArgs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientArgs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientArgs"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}setup\0\u{1}mark\0")
 
@@ -1497,7 +1497,7 @@ extension Grpc_Testing_ClientArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_ServerConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ServerConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ServerConfig"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}server_type\0\u{3}security_params\0\u{2}\u{2}port\0\u{4}\u{3}async_server_threads\0\u{3}core_limit\0\u{3}payload_config\0\u{3}core_list\0\u{3}other_server_api\0\u{3}threads_per_cq\0\u{4}\u{9}server_processes\0\u{4}T\u{f}resource_quota_size\0\u{3}channel_args\0")
 
@@ -1586,7 +1586,7 @@ extension Grpc_Testing_ServerConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Grpc_Testing_ServerArgs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ServerArgs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ServerArgs"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}setup\0\u{1}mark\0")
 
@@ -1653,7 +1653,7 @@ extension Grpc_Testing_ServerArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_ServerStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ServerStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ServerStatus"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}stats\0\u{1}port\0\u{1}cores\0")
 
@@ -1697,7 +1697,7 @@ extension Grpc_Testing_ServerStatus: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Grpc_Testing_CoreRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_CoreRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".CoreRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1716,7 +1716,7 @@ extension Grpc_Testing_CoreRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Grpc_Testing_CoreResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_CoreResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".CoreResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cores\0")
 
@@ -1746,7 +1746,7 @@ extension Grpc_Testing_CoreResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Grpc_Testing_Void: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_Void: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Void"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1765,7 +1765,7 @@ extension Grpc_Testing_Void: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Grpc_Testing_Scenario: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_Scenario: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Scenario"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}client_config\0\u{3}num_clients\0\u{3}server_config\0\u{3}num_servers\0\u{3}warmup_seconds\0\u{3}benchmark_seconds\0\u{3}spawn_local_worker_count\0")
 
@@ -1884,7 +1884,7 @@ extension Grpc_Testing_Scenario: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Grpc_Testing_Scenarios: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_Scenarios: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Scenarios"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scenarios\0")
 
@@ -1914,7 +1914,7 @@ extension Grpc_Testing_Scenarios: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Grpc_Testing_ScenarioResultSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ScenarioResultSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ScenarioResultSummary"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}qps\0\u{3}qps_per_server_core\0\u{3}server_system_time\0\u{3}server_user_time\0\u{3}client_system_time\0\u{3}client_user_time\0\u{3}latency_50\0\u{3}latency_90\0\u{3}latency_95\0\u{3}latency_99\0\u{3}latency_999\0\u{3}server_cpu_usage\0\u{3}successful_requests_per_second\0\u{3}failed_requests_per_second\0\u{3}client_polls_per_request\0\u{3}server_polls_per_request\0\u{3}server_queries_per_cpu_sec\0\u{3}client_queries_per_cpu_sec\0\u{3}start_time\0\u{3}end_time\0")
 
@@ -2117,7 +2117,7 @@ extension Grpc_Testing_ScenarioResultSummary: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Grpc_Testing_ScenarioResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ScenarioResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ScenarioResult"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scenario\0\u{1}latencies\0\u{3}client_stats\0\u{3}server_stats\0\u{3}server_cores\0\u{1}summary\0\u{3}client_success\0\u{3}server_success\0\u{3}request_results\0")
 

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_messages.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_messages.grpc.swift
@@ -22,6 +22,6 @@
 // Source: grpc/testing/messages.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 // This file contained no services.

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_messages.pb.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_messages.pb.swift
@@ -36,13 +36,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// The type of payload that should be returned.
-package enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum, Swift.CaseIterable {
+package nonisolated enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum, Swift.CaseIterable {
   package typealias RawValue = Int
 
   /// Compressable text format.
@@ -80,7 +80,7 @@ package enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum, Swift.CaseIterable {
 /// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
 /// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
 /// how this detection is done is context and server dependent.
-package enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum, Swift.CaseIterable {
+package nonisolated enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum, Swift.CaseIterable {
   package typealias RawValue = Int
 
   /// Server didn't detect the route that a client took to reach it.
@@ -127,7 +127,7 @@ package enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum, Swift.CaseIterabl
 /// TODO(dgq): Go back to using well-known types once
 /// https://github.com/grpc/grpc/issues/6980 has been fixed.
 /// import "google/protobuf/wrappers.proto";
-package struct Grpc_Testing_BoolValue: Sendable {
+package nonisolated struct Grpc_Testing_BoolValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -141,7 +141,7 @@ package struct Grpc_Testing_BoolValue: Sendable {
 }
 
 /// A block of data, to simply increase gRPC message size.
-package struct Grpc_Testing_Payload: Sendable {
+package nonisolated struct Grpc_Testing_Payload: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -159,7 +159,7 @@ package struct Grpc_Testing_Payload: Sendable {
 
 /// A protobuf representation for grpc status. This is used by test
 /// clients to specify a status that the server should attempt to return.
-package struct Grpc_Testing_EchoStatus: Sendable {
+package nonisolated struct Grpc_Testing_EchoStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -174,7 +174,7 @@ package struct Grpc_Testing_EchoStatus: Sendable {
 }
 
 /// Unary request.
-package struct Grpc_Testing_SimpleRequest: Sendable {
+package nonisolated struct Grpc_Testing_SimpleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -263,7 +263,7 @@ package struct Grpc_Testing_SimpleRequest: Sendable {
 }
 
 /// Unary response, as configured by the request.
-package struct Grpc_Testing_SimpleResponse: Sendable {
+package nonisolated struct Grpc_Testing_SimpleResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -303,7 +303,7 @@ package struct Grpc_Testing_SimpleResponse: Sendable {
 }
 
 /// Client-streaming request.
-package struct Grpc_Testing_StreamingInputCallRequest: Sendable {
+package nonisolated struct Grpc_Testing_StreamingInputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -340,7 +340,7 @@ package struct Grpc_Testing_StreamingInputCallRequest: Sendable {
 }
 
 /// Client-streaming response.
-package struct Grpc_Testing_StreamingInputCallResponse: Sendable {
+package nonisolated struct Grpc_Testing_StreamingInputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +354,7 @@ package struct Grpc_Testing_StreamingInputCallResponse: Sendable {
 }
 
 /// Configuration for a particular response.
-package struct Grpc_Testing_ResponseParameters: Sendable {
+package nonisolated struct Grpc_Testing_ResponseParameters: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -379,15 +379,27 @@ package struct Grpc_Testing_ResponseParameters: Sendable {
   /// Clears the value of `compressed`. Subsequent reads from it will return its default value.
   package mutating func clearCompressed() {self._compressed = nil}
 
+  /// Whether to request the server to send the requesting peer's socket
+  /// address in the response.
+  package var fillPeerSocketAddress: Grpc_Testing_BoolValue {
+    get {_fillPeerSocketAddress ?? Grpc_Testing_BoolValue()}
+    set {_fillPeerSocketAddress = newValue}
+  }
+  /// Returns true if `fillPeerSocketAddress` has been explicitly set.
+  package var hasFillPeerSocketAddress: Bool {self._fillPeerSocketAddress != nil}
+  /// Clears the value of `fillPeerSocketAddress`. Subsequent reads from it will return its default value.
+  package mutating func clearFillPeerSocketAddress() {self._fillPeerSocketAddress = nil}
+
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   package init() {}
 
   fileprivate var _compressed: Grpc_Testing_BoolValue? = nil
+  fileprivate var _fillPeerSocketAddress: Grpc_Testing_BoolValue? = nil
 }
 
 /// Server-streaming request.
-package struct Grpc_Testing_StreamingOutputCallRequest: Sendable {
+package nonisolated struct Grpc_Testing_StreamingOutputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -441,7 +453,7 @@ package struct Grpc_Testing_StreamingOutputCallRequest: Sendable {
 }
 
 /// Server-streaming response, as configured by the request and parameters.
-package struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
+package nonisolated struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -456,6 +468,9 @@ package struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
   /// Clears the value of `payload`. Subsequent reads from it will return its default value.
   package mutating func clearPayload() {self._payload = nil}
 
+  /// The peer's socket address if requested.
+  package var peerSocketAddress: String = String()
+
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   package init() {}
@@ -465,7 +480,7 @@ package struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
 
 /// For reconnect interop test only.
 /// Client tells server what reconnection parameters it used.
-package struct Grpc_Testing_ReconnectParams: Sendable {
+package nonisolated struct Grpc_Testing_ReconnectParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -480,7 +495,7 @@ package struct Grpc_Testing_ReconnectParams: Sendable {
 /// For reconnect interop test only.
 /// Server tells client whether its reconnects are following the spec and the
 /// reconnect backoffs it saw.
-package struct Grpc_Testing_ReconnectInfo: Sendable {
+package nonisolated struct Grpc_Testing_ReconnectInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -494,7 +509,7 @@ package struct Grpc_Testing_ReconnectInfo: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_LoadBalancerStatsRequest: Sendable {
+package nonisolated struct Grpc_Testing_LoadBalancerStatsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -515,7 +530,7 @@ package struct Grpc_Testing_LoadBalancerStatsRequest: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
+package nonisolated struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -533,7 +548,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum MetadataType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  package nonisolated enum MetadataType: SwiftProtobuf.Enum, Swift.CaseIterable {
     package typealias RawValue = Int
     case unknown // = 0
     case initial // = 1
@@ -571,7 +586,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
 
   }
 
-  package struct MetadataEntry: Sendable {
+  package nonisolated struct MetadataEntry: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -591,7 +606,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
     package init() {}
   }
 
-  package struct RpcMetadata: Sendable {
+  package nonisolated struct RpcMetadata: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -605,7 +620,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
     package init() {}
   }
 
-  package struct MetadataByPeer: Sendable {
+  package nonisolated struct MetadataByPeer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -618,7 +633,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
     package init() {}
   }
 
-  package struct RpcsByPeer: Sendable {
+  package nonisolated struct RpcsByPeer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -635,7 +650,7 @@ package struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
 }
 
 /// Request for retrieving a test client's accumulated stats.
-package struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest: Sendable {
+package nonisolated struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -646,7 +661,7 @@ package struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest: Sendable {
 }
 
 /// Accumulated stats for RPCs sent by a test client.
-package struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse: Sendable {
+package nonisolated struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -675,7 +690,7 @@ package struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package struct MethodStats: Sendable {
+  package nonisolated struct MethodStats: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -696,7 +711,7 @@ package struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse: Sendable {
 }
 
 /// Configurations for a test client.
-package struct Grpc_Testing_ClientConfigureRequest: Sendable {
+package nonisolated struct Grpc_Testing_ClientConfigureRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -714,7 +729,7 @@ package struct Grpc_Testing_ClientConfigureRequest: Sendable {
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Type of RPCs to send.
-  package enum RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  package nonisolated enum RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
     package typealias RawValue = Int
     case emptyCall // = 0
     case unaryCall // = 1
@@ -749,7 +764,7 @@ package struct Grpc_Testing_ClientConfigureRequest: Sendable {
   }
 
   /// Metadata to be attached for the given type of RPCs.
-  package struct Metadata: Sendable {
+  package nonisolated struct Metadata: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -769,7 +784,7 @@ package struct Grpc_Testing_ClientConfigureRequest: Sendable {
 }
 
 /// Response for updating a test client's configuration.
-package struct Grpc_Testing_ClientConfigureResponse: Sendable {
+package nonisolated struct Grpc_Testing_ClientConfigureResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -779,7 +794,7 @@ package struct Grpc_Testing_ClientConfigureResponse: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_MemorySize: Sendable {
+package nonisolated struct Grpc_Testing_MemorySize: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -794,7 +809,7 @@ package struct Grpc_Testing_MemorySize: Sendable {
 /// Metrics data the server will update and send to the client. It mirrors orca load report
 /// https://github.com/cncf/xds/blob/eded343319d09f30032952beda9840bbd3dcf7ac/xds/data/orca/v3/orca_load_report.proto#L15,
 /// but avoids orca dependency. Used by both per-query and out-of-band reporting tests.
-package struct Grpc_Testing_TestOrcaReport: Sendable {
+package nonisolated struct Grpc_Testing_TestOrcaReport: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -813,7 +828,7 @@ package struct Grpc_Testing_TestOrcaReport: Sendable {
 }
 
 /// Status that will be return to callers of the Hook method
-package struct Grpc_Testing_SetReturnStatusRequest: Sendable {
+package nonisolated struct Grpc_Testing_SetReturnStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -827,7 +842,7 @@ package struct Grpc_Testing_SetReturnStatusRequest: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_HookRequest: Sendable {
+package nonisolated struct Grpc_Testing_HookRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -843,7 +858,7 @@ package struct Grpc_Testing_HookRequest: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum HookRequestCommand: SwiftProtobuf.Enum, Swift.CaseIterable {
+  package nonisolated enum HookRequestCommand: SwiftProtobuf.Enum, Swift.CaseIterable {
     package typealias RawValue = Int
 
     /// Default value
@@ -896,7 +911,7 @@ package struct Grpc_Testing_HookRequest: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_HookResponse: Sendable {
+package nonisolated struct Grpc_Testing_HookResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -908,17 +923,17 @@ package struct Grpc_Testing_HookResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.testing"
+fileprivate nonisolated let _protobuf_package = "grpc.testing"
 
-extension Grpc_Testing_PayloadType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_PayloadType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSABLE\0")
 }
 
-extension Grpc_Testing_GrpclbRouteType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_GrpclbRouteType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0GRPCLB_ROUTE_TYPE_UNKNOWN\0\u{1}GRPCLB_ROUTE_TYPE_FALLBACK\0\u{1}GRPCLB_ROUTE_TYPE_BACKEND\0")
 }
 
-extension Grpc_Testing_BoolValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_BoolValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".BoolValue"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0")
 
@@ -948,7 +963,7 @@ extension Grpc_Testing_BoolValue: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Grpc_Testing_Payload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_Payload: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Payload"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}body\0")
 
@@ -983,7 +998,7 @@ extension Grpc_Testing_Payload: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Grpc_Testing_EchoStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_EchoStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".EchoStatus"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}code\0\u{1}message\0")
 
@@ -1018,7 +1033,7 @@ extension Grpc_Testing_EchoStatus: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_SimpleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_SimpleRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SimpleRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_type\0\u{3}response_size\0\u{1}payload\0\u{3}fill_username\0\u{3}fill_oauth_scope\0\u{3}response_compressed\0\u{3}response_status\0\u{3}expect_compressed\0\u{3}fill_server_id\0\u{3}fill_grpclb_route_type\0\u{3}orca_per_query_report\0")
 
@@ -1102,7 +1117,7 @@ extension Grpc_Testing_SimpleRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Grpc_Testing_SimpleResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_SimpleResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SimpleResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0\u{1}username\0\u{3}oauth_scope\0\u{3}server_id\0\u{3}grpclb_route_type\0\u{1}hostname\0")
 
@@ -1161,7 +1176,7 @@ extension Grpc_Testing_SimpleResponse: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Grpc_Testing_StreamingInputCallRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_StreamingInputCallRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".StreamingInputCallRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0\u{3}expect_compressed\0")
 
@@ -1200,7 +1215,7 @@ extension Grpc_Testing_StreamingInputCallRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Grpc_Testing_StreamingInputCallResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_StreamingInputCallResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".StreamingInputCallResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}aggregated_payload_size\0")
 
@@ -1230,9 +1245,9 @@ extension Grpc_Testing_StreamingInputCallResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ResponseParameters"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}size\0\u{3}interval_us\0\u{1}compressed\0")
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}size\0\u{3}interval_us\0\u{1}compressed\0\u{3}fill_peer_socket_address\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1243,6 +1258,7 @@ extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf.
       case 1: try { try decoder.decodeSingularInt32Field(value: &self.size) }()
       case 2: try { try decoder.decodeSingularInt32Field(value: &self.intervalUs) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._compressed) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._fillPeerSocketAddress) }()
       default: break
       }
     }
@@ -1262,6 +1278,9 @@ extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf.
     try { if let v = self._compressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._fillPeerSocketAddress {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1269,12 +1288,13 @@ extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf.
     if lhs.size != rhs.size {return false}
     if lhs.intervalUs != rhs.intervalUs {return false}
     if lhs._compressed != rhs._compressed {return false}
+    if lhs._fillPeerSocketAddress != rhs._fillPeerSocketAddress {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Grpc_Testing_StreamingOutputCallRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_StreamingOutputCallRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".StreamingOutputCallRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_type\0\u{3}response_parameters\0\u{1}payload\0\u{4}\u{4}response_status\0\u{3}orca_oob_report\0")
 
@@ -1328,9 +1348,9 @@ extension Grpc_Testing_StreamingOutputCallRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".StreamingOutputCallResponse"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0")
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0\u{3}peer_socket_address\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1339,6 +1359,7 @@ extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, Swift
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._payload) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.peerSocketAddress) }()
       default: break
       }
     }
@@ -1352,17 +1373,21 @@ extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, Swift
     try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
+    if !self.peerSocketAddress.isEmpty {
+      try visitor.visitSingularStringField(value: self.peerSocketAddress, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   package static func ==(lhs: Grpc_Testing_StreamingOutputCallResponse, rhs: Grpc_Testing_StreamingOutputCallResponse) -> Bool {
     if lhs._payload != rhs._payload {return false}
+    if lhs.peerSocketAddress != rhs.peerSocketAddress {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Grpc_Testing_ReconnectParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ReconnectParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ReconnectParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}max_reconnect_backoff_ms\0")
 
@@ -1392,7 +1417,7 @@ extension Grpc_Testing_ReconnectParams: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Grpc_Testing_ReconnectInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ReconnectInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ReconnectInfo"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}passed\0\u{3}backoff_ms\0")
 
@@ -1427,7 +1452,7 @@ extension Grpc_Testing_ReconnectInfo: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LoadBalancerStatsRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}num_rpcs\0\u{3}timeout_sec\0\u{3}metadata_keys\0")
 
@@ -1467,7 +1492,7 @@ extension Grpc_Testing_LoadBalancerStatsRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LoadBalancerStatsResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rpcs_by_peer\0\u{3}num_failures\0\u{3}rpcs_by_method\0\u{3}metadatas_by_peer\0")
 
@@ -1512,11 +1537,11 @@ extension Grpc_Testing_LoadBalancerStatsResponse: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse.MetadataType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}INITIAL\0\u{1}TRAILING\0")
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse.MetadataEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_LoadBalancerStatsResponse.protoMessageName + ".MetadataEntry"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0\u{1}type\0")
 
@@ -1556,7 +1581,7 @@ extension Grpc_Testing_LoadBalancerStatsResponse.MetadataEntry: SwiftProtobuf.Me
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse.RpcMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse.RpcMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_LoadBalancerStatsResponse.protoMessageName + ".RpcMetadata"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metadata\0")
 
@@ -1586,7 +1611,7 @@ extension Grpc_Testing_LoadBalancerStatsResponse.RpcMetadata: SwiftProtobuf.Mess
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataByPeer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse.MetadataByPeer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_LoadBalancerStatsResponse.protoMessageName + ".MetadataByPeer"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rpc_metadata\0")
 
@@ -1616,7 +1641,7 @@ extension Grpc_Testing_LoadBalancerStatsResponse.MetadataByPeer: SwiftProtobuf.M
   }
 }
 
-extension Grpc_Testing_LoadBalancerStatsResponse.RpcsByPeer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerStatsResponse.RpcsByPeer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_LoadBalancerStatsResponse.protoMessageName + ".RpcsByPeer"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rpcs_by_peer\0")
 
@@ -1646,7 +1671,7 @@ extension Grpc_Testing_LoadBalancerStatsResponse.RpcsByPeer: SwiftProtobuf.Messa
   }
 }
 
-extension Grpc_Testing_LoadBalancerAccumulatedStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerAccumulatedStatsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LoadBalancerAccumulatedStatsRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1665,7 +1690,7 @@ extension Grpc_Testing_LoadBalancerAccumulatedStatsRequest: SwiftProtobuf.Messag
   }
 }
 
-extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LoadBalancerAccumulatedStatsResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}num_rpcs_started_by_method\0\u{3}num_rpcs_succeeded_by_method\0\u{3}num_rpcs_failed_by_method\0\u{3}stats_per_method\0")
 
@@ -1710,7 +1735,7 @@ extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse: SwiftProtobuf.Messa
   }
 }
 
-extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse.MethodStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse.MethodStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_LoadBalancerAccumulatedStatsResponse.protoMessageName + ".MethodStats"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rpcs_started\0\u{1}result\0")
 
@@ -1745,7 +1770,7 @@ extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse.MethodStats: SwiftPr
   }
 }
 
-extension Grpc_Testing_ClientConfigureRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientConfigureRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientConfigureRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}types\0\u{1}metadata\0\u{3}timeout_sec\0")
 
@@ -1785,11 +1810,11 @@ extension Grpc_Testing_ClientConfigureRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Grpc_Testing_ClientConfigureRequest.RpcType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientConfigureRequest.RpcType: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0EMPTY_CALL\0\u{1}UNARY_CALL\0")
 }
 
-extension Grpc_Testing_ClientConfigureRequest.Metadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientConfigureRequest.Metadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Grpc_Testing_ClientConfigureRequest.protoMessageName + ".Metadata"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}key\0\u{1}value\0")
 
@@ -1829,7 +1854,7 @@ extension Grpc_Testing_ClientConfigureRequest.Metadata: SwiftProtobuf.Message, S
   }
 }
 
-extension Grpc_Testing_ClientConfigureResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientConfigureResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientConfigureResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1848,7 +1873,7 @@ extension Grpc_Testing_ClientConfigureResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Grpc_Testing_MemorySize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_MemorySize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".MemorySize"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}rss\0")
 
@@ -1878,7 +1903,7 @@ extension Grpc_Testing_MemorySize: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Grpc_Testing_TestOrcaReport: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_TestOrcaReport: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".TestOrcaReport"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}cpu_utilization\0\u{3}memory_utilization\0\u{3}request_cost\0\u{1}utilization\0")
 
@@ -1923,7 +1948,7 @@ extension Grpc_Testing_TestOrcaReport: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Grpc_Testing_SetReturnStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_SetReturnStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SetReturnStatusRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grpc_code_to_return\0\u{3}grpc_status_description\0")
 
@@ -1958,7 +1983,7 @@ extension Grpc_Testing_SetReturnStatusRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Grpc_Testing_HookRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_HookRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".HookRequest"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}command\0\u{3}grpc_code_to_return\0\u{3}grpc_status_description\0\u{3}server_port\0")
 
@@ -2003,11 +2028,11 @@ extension Grpc_Testing_HookRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Grpc_Testing_HookRequest.HookRequestCommand: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_HookRequest.HookRequestCommand: SwiftProtobuf._ProtoNameProviding {
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSPECIFIED\0\u{1}START\0\u{1}STOP\0\u{1}RETURN\0")
 }
 
-extension Grpc_Testing_HookResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_HookResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".HookResponse"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_payloads.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_payloads.grpc.swift
@@ -20,6 +20,6 @@
 // Source: grpc/testing/payloads.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 // This file contained no services.

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_payloads.pb.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_payloads.pb.swift
@@ -29,12 +29,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-package struct Grpc_Testing_ByteBufferParams: Sendable {
+package nonisolated struct Grpc_Testing_ByteBufferParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ package struct Grpc_Testing_ByteBufferParams: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_SimpleProtoParams: Sendable {
+package nonisolated struct Grpc_Testing_SimpleProtoParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -64,7 +64,7 @@ package struct Grpc_Testing_SimpleProtoParams: Sendable {
 
 /// TODO (vpai): Fill this in once the details of complex, representative
 ///              protos are decided
-package struct Grpc_Testing_ComplexProtoParams: Sendable {
+package nonisolated struct Grpc_Testing_ComplexProtoParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -74,7 +74,7 @@ package struct Grpc_Testing_ComplexProtoParams: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_PayloadConfig: Sendable {
+package nonisolated struct Grpc_Testing_PayloadConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -107,7 +107,7 @@ package struct Grpc_Testing_PayloadConfig: Sendable {
 
   package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  package enum OneOf_Payload: Equatable, Sendable {
+  package nonisolated enum OneOf_Payload: Equatable, Sendable {
     case bytebufParams(Grpc_Testing_ByteBufferParams)
     case simpleParams(Grpc_Testing_SimpleProtoParams)
     case complexParams(Grpc_Testing_ComplexProtoParams)
@@ -119,9 +119,9 @@ package struct Grpc_Testing_PayloadConfig: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.testing"
+fileprivate nonisolated let _protobuf_package = "grpc.testing"
 
-extension Grpc_Testing_ByteBufferParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ByteBufferParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ByteBufferParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}req_size\0\u{3}resp_size\0")
 
@@ -156,7 +156,7 @@ extension Grpc_Testing_ByteBufferParams: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Grpc_Testing_SimpleProtoParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_SimpleProtoParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SimpleProtoParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}req_size\0\u{3}resp_size\0")
 
@@ -191,7 +191,7 @@ extension Grpc_Testing_SimpleProtoParams: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Grpc_Testing_ComplexProtoParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ComplexProtoParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ComplexProtoParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -210,7 +210,7 @@ extension Grpc_Testing_ComplexProtoParams: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Grpc_Testing_PayloadConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_PayloadConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".PayloadConfig"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}bytebuf_params\0\u{3}simple_params\0\u{3}complex_params\0")
 

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_stats.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_stats.grpc.swift
@@ -20,6 +20,6 @@
 // Source: grpc/testing/stats.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 // This file contained no services.

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_stats.pb.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_stats.pb.swift
@@ -29,12 +29,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-package struct Grpc_Testing_ServerStats: Sendable {
+package nonisolated struct Grpc_Testing_ServerStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -76,7 +76,7 @@ package struct Grpc_Testing_ServerStats: Sendable {
 }
 
 /// Histogram params based on grpc/support/histogram.c
-package struct Grpc_Testing_HistogramParams: Sendable {
+package nonisolated struct Grpc_Testing_HistogramParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -93,7 +93,7 @@ package struct Grpc_Testing_HistogramParams: Sendable {
 }
 
 /// Histogram data based on grpc/support/histogram.c
-package struct Grpc_Testing_HistogramData: Sendable {
+package nonisolated struct Grpc_Testing_HistogramData: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -115,7 +115,7 @@ package struct Grpc_Testing_HistogramData: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_RequestResultCount: Sendable {
+package nonisolated struct Grpc_Testing_RequestResultCount: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -129,7 +129,7 @@ package struct Grpc_Testing_RequestResultCount: Sendable {
   package init() {}
 }
 
-package struct Grpc_Testing_ClientStats: Sendable {
+package nonisolated struct Grpc_Testing_ClientStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -177,9 +177,9 @@ package struct Grpc_Testing_ClientStats: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.testing"
+fileprivate nonisolated let _protobuf_package = "grpc.testing"
 
-extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ServerStats"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_elapsed\0\u{3}time_user\0\u{3}time_system\0\u{3}total_cpu_time\0\u{3}idle_cpu_time\0\u{3}cq_poll_count\0\u{3}core_stats\0")
 
@@ -243,7 +243,7 @@ extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Grpc_Testing_HistogramParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_HistogramParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".HistogramParams"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resolution\0\u{3}max_possible\0")
 
@@ -278,7 +278,7 @@ extension Grpc_Testing_HistogramParams: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Grpc_Testing_HistogramData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_HistogramData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".HistogramData"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}bucket\0\u{3}min_seen\0\u{3}max_seen\0\u{1}sum\0\u{3}sum_of_squares\0\u{1}count\0")
 
@@ -333,7 +333,7 @@ extension Grpc_Testing_HistogramData: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Grpc_Testing_RequestResultCount: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_RequestResultCount: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".RequestResultCount"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_code\0\u{1}count\0")
 
@@ -368,7 +368,7 @@ extension Grpc_Testing_RequestResultCount: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Grpc_Testing_ClientStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Testing_ClientStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ClientStats"
   package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}latencies\0\u{3}time_elapsed\0\u{3}time_user\0\u{3}time_system\0\u{3}request_results\0\u{3}cq_poll_count\0\u{3}core_stats\0")
 

--- a/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_worker_service.grpc.swift
+++ b/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated/grpc_testing_worker_service.grpc.swift
@@ -23,7 +23,7 @@
 // Source: grpc/testing/worker_service.proto
 //
 // For information on using the generated types, please see the documentation:
-//   https://github.com/grpc/grpc-swift
+//   https://github.com/grpc/grpc-swift-2
 
 import GRPCCore
 import GRPCProtobuf

--- a/dev/check-generated-code.sh
+++ b/dev/check-generated-code.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+## Copyright 2024, gRPC Authors All rights reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Re-generate everything.
+log "Regenerating protos..."
+"$here"/protos/generate.sh
+
+# Check for changes.
+GIT_PAGER='' git diff --exit-code '*.swift'
+
+log "Generated code is up-to-date"

--- a/dev/protos/generate.sh
+++ b/dev/protos/generate.sh
@@ -83,7 +83,7 @@ function generate_perf_test_services {
     "$here/upstream/grpc/testing/benchmark_service.proto"
     "$here/upstream/grpc/testing/worker_service.proto"
   )
-  local output="$root/IntegrationTests/grpc-performance-tests/Sources/Generated"
+  local output="$root/IntegrationTests/grpc-performance-tests/Sources/WorkerService/Generated"
 
   generate_message "$here/upstream/grpc/core/stats.proto" "$here/upstream" "$output" "Visibility=Package" "FileNaming=PathToUnderscores"
 

--- a/dev/protos/generate.sh
+++ b/dev/protos/generate.sh
@@ -17,16 +17,17 @@ set -eu
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 root="$here/../.."
-protoc=$(which protoc)
 
 # Checkout and build the plugins.
 build_dir=$(mktemp -d)
 git clone https://github.com/grpc/grpc-swift-protobuf --depth 1 "$build_dir"
+swift build --package-path "$build_dir" --product protoc
 swift build --package-path "$build_dir" --product protoc-gen-swift
 swift build --package-path "$build_dir" --product protoc-gen-grpc-swift-2
 
 # Grab the plugin paths.
 bin_path=$(swift build --package-path "$build_dir" --show-bin-path)
+protoc="$bin_path/protoc"
 protoc_gen_swift="$bin_path/protoc-gen-swift"
 protoc_gen_grpc_swift="$bin_path/protoc-gen-grpc-swift-2"
 

--- a/dev/protos/upstream/grpc/testing/messages.proto
+++ b/dev/protos/upstream/grpc/testing/messages.proto
@@ -158,6 +158,10 @@ message ResponseParameters {
   // implement the full compression tests by introspecting the call to verify
   // the response's compression status.
   BoolValue compressed = 3;
+
+  // Whether to request the server to send the requesting peer's socket
+  // address in the response.
+  BoolValue fill_peer_socket_address = 4;
 }
 
 // Server-streaming request.
@@ -185,6 +189,9 @@ message StreamingOutputCallRequest {
 message StreamingOutputCallResponse {
   // Payload to increase response size.
   Payload payload = 1;
+
+  // The peer's socket address if requested.
+  string peer_socket_address = 2;
 }
 
 // For reconnect interop test only.


### PR DESCRIPTION
Now that `grpc-swift-protobuf` is updated, the generated code differers slightly.

Other changes:
* Use vendored protoc in script
* Fetch updates to .proto from upstream
* Fix broken path to /Generated
* Add help script to check generated code