### PR TITLE
Suppress fcntl errors on the listener's accept path

### DIFF
--- a/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/HTTP2ServerTransport+Posix.swift
@@ -126,7 +126,15 @@ extension HTTP2ServerTransport {
         let serverChannel = try await ServerBootstrap(group: self.eventLoopGroup)
           .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
           .serverChannelInitializer { channel in
+            #if canImport(Darwin)
+            channel.eventLoop.makeCompletedFuture {
+              try channel.pipeline.syncOperations.addHandler(SwallowFcntlFailedErrorHandler())
+            }.flatMap {
+              listenerConfigurator.configure(channel: channel)
+            }
+            #else
             listenerConfigurator.configure(channel: channel)
+            #endif
           }
           .bind(to: self.address) { channel in
             channel.eventLoop.makeCompletedFuture {

--- a/Sources/GRPCNIOTransportHTTP2Posix/SwallowFcntlFailedErrorHandler.swift
+++ b/Sources/GRPCNIOTransportHTTP2Posix/SwallowFcntlFailedErrorHandler.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal import NIOCore
+internal import NIOPosix
+
+/// A handler for the listening channel which drops `NIOFcntlFailedError`s.
+///
+/// On Darwin, `fcntl(2)` on a just-accepted socket whose peer has already closed can fail with
+/// `EINVAL`, which NIO surfaces as a `NIOFcntlFailedError`. NIO treats this as recoverable and
+/// keeps the listening channel open but still fires the error down the pipeline. The socket
+/// which failed to be configured has already been closed by NIO and no `Channel` was created
+/// for it: the error is is purely informational.
+///
+/// When the listening channel is wrapped in a `NIOAsyncChannel`: its handler finishes the
+/// stream of accepted connections with _any_ error it catches.
+final class SwallowFcntlFailedErrorHandler: ChannelInboundHandler {
+  typealias InboundIn = Any
+  typealias InboundOut = Any
+
+  func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    switch error {
+    case is NIOFcntlFailedError:
+      ()  // Okay, the accepted socket has already been closed by NIO.
+    default:
+      context.fireErrorCaught(error)
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

On Darwin, 'fcntl(2)' on a just-accepted socket can fail with EINVAL, which NIO surfaces as a 'NIOFcntlFailedError'. NIO closes the socket directly and fires the error down the pipeline for informational purposes.

However, when wrapped in a NIOAsyncChannel channel the read loop throws this error which causes the server to shutdown.

Note that testing this reliably is difficult: the error type is public but its init is not so we cannot synthesize the failure. Hitting this is possible in release builds after serveral thousand iterations but much less so in debug builds.

Modifications:

- Ignore the error on Darwin

Result:

Fewer errors